### PR TITLE
fix init-agent-docs context bootstrap (Steps 4, 5, 6)

### DIFF
--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -1,9 +1,0 @@
-# Project Context
-
-One or two sentences describing what this project does and why this context exists.
-
-## Language
-
-**Term**:
-A one- or two-sentence definition. Define what it IS, not what it does.
-_Avoid_: Other words for the same concept

--- a/.agent-docs/issues/chore/init-agent-docs-context-bootstrap.md
+++ b/.agent-docs/issues/chore/init-agent-docs-context-bootstrap.md
@@ -1,0 +1,39 @@
+# Issues: chore/init-agent-docs-context-bootstrap
+
+## Fix init-agent-docs context bootstrap (Steps 4, 5, 6)
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3, 4
+
+### What to build
+
+Update `init-agent-docs/SKILL.md` and `init-agent-docs/REFERENCE.md` so that the skill
+always produces or validates a domain glossary, rather than copying a non-existent template.
+
+Three step changes, two files:
+
+- **Step 4**: remove the "skip to Step 7" branch when `context.md` already exists; route to
+  Step 6 (review sub-path) instead, so every run reviews the existing glossary.
+- **Step 5** (REFERENCE.md only): change the skip target after a successful file move from
+  "skip to Step 7" to "continue to Step 6 (review sub-path)", so a newly moved file is
+  immediately reviewed.
+- **Step 6**: replace the broken `CONTEXT-TEMPLATE.md` verbatim-copy instruction with two
+  sub-paths:
+  - **Generate** (no `context.md` found): read `CONTEXT-FORMAT.md`, read the codebase,
+    write a full domain glossary to `.agent-docs/context.md`.
+  - **Review and improve** (file exists or was just moved): read `CONTEXT-FORMAT.md`, audit
+    the existing file against its rules, write improvements if shortcomings are found, or
+    report "no improvements needed" if already compliant.
+
+### Acceptance criteria
+
+- [ ] `SKILL.md` Step 4 no longer says "skip to Step 7" when `context.md` exists; it routes to Step 6.
+- [ ] `REFERENCE.md` Step 4 no longer says "skip to Step 7" when `context.md` exists; it routes to Step 6.
+- [ ] `REFERENCE.md` Step 5 no longer says "skip to Step 7" after a successful file move; it continues to Step 6.
+- [ ] `REFERENCE.md` Step 6 defines a **generate** sub-path that reads `CONTEXT-FORMAT.md` and the codebase before writing `context.md`.
+- [ ] `REFERENCE.md` Step 6 defines a **review and improve** sub-path with explicit audit criteria, an "improved" report variant, and a "no improvements needed" report variant.
+- [ ] `SKILL.md` Step 6 summary reflects the two sub-paths (generate vs review-and-improve).
+- [ ] Neither `SKILL.md` nor `REFERENCE.md` contains any reference to `CONTEXT-TEMPLATE.md`.
+
+---

--- a/.agent-docs/specs/chore/init-agent-docs-context-bootstrap.md
+++ b/.agent-docs/specs/chore/init-agent-docs-context-bootstrap.md
@@ -1,0 +1,117 @@
+# init-agent-docs Context Bootstrap
+
+## Problem Statement
+
+When `init-agent-docs` runs and no existing `context.md` is found, Step 6 instructs the
+agent to write `CONTEXT-TEMPLATE.md` verbatim to `.agent-docs/context.md`. That template
+file does not exist — the reference is broken. More importantly, even if it did exist, a
+verbatim copy would produce a generic placeholder rather than a domain glossary grounded
+in the actual codebase.
+
+Additionally, when a `context.md` already exists, Step 4 short-circuits the entire flow and
+skips to Step 7. This means an existing glossary is never reviewed for quality or compliance
+with the format rules in `CONTEXT-FORMAT.md` — gaps, weak definitions, and missing avoid-lists
+accumulate silently.
+
+## Solution
+
+Fix Step 4 and Step 6 in both `SKILL.md` and `REFERENCE.md`:
+
+- **Step 4**: when `context.md` already exists (or is moved into place by Step 5), route to
+  Step 6 for review rather than skipping to Step 7.
+- **Step 6**: two sub-paths replace the broken template-copy instruction:
+  - **Generate** (no `context.md` found): read the codebase to understand the domain, then
+    write a full, comprehensive `context.md` following the structure and rules in
+    `CONTEXT-FORMAT.md`.
+  - **Review and improve** (file exists or was just moved): read `CONTEXT-FORMAT.md`, audit
+    the existing file against its rules, write improvements if shortcomings are found, and
+    report "no improvements needed" if the file is already fully compliant.
+
+## User Stories
+
+1. As a developer bootstrapping a new repo, I want `init-agent-docs` to produce a real domain
+   glossary from my codebase, so that I get a useful `context.md` rather than a generic
+   placeholder.
+2. As a developer re-running `init-agent-docs` on a repo with an existing `context.md`, I want
+   the skill to review and improve it, so that the glossary stays aligned with the
+   `CONTEXT-FORMAT.md` quality rules over time.
+3. As a developer with a high-quality `context.md`, I want `init-agent-docs` to leave it alone
+   if it is already compliant, so that I do not get spurious rewrites.
+4. As a skill maintainer, I want Steps 4 and 5 to route to Step 6 in all paths, so that every
+   run of the skill produces or validates a domain glossary.
+
+## Implementation Decisions
+
+Two files change — `init-agent-docs/SKILL.md` and `init-agent-docs/REFERENCE.md`:
+
+**Step 4 change (both files):**
+
+- Remove the "skip to Step 7" branch.
+- When `context.md` exists: report "`.agent-docs/context.md` found — proceeding to review."
+  and continue to Step 6 (review sub-path).
+- When `context.md` does not exist: continue to Step 5 as before.
+
+**Step 5 change (REFERENCE.md only — the skip target):**
+
+- When a file is found and moved: instead of "skip to Step 7", continue to Step 6
+  (review sub-path) so the newly moved file is immediately reviewed.
+- The "multiple files found" and "no files found" branches are unchanged.
+
+**Step 6 change (both files):**
+Replace the single "write CONTEXT-TEMPLATE.md verbatim" instruction with two sub-paths:
+
+- **Generate sub-path** (no `context.md` found after Steps 4–5):
+  1. Read `CONTEXT-FORMAT.md` from this skill's directory to understand the required
+     structure and rules.
+  2. Read the codebase to identify domain-specific concepts: skill names, workflow concepts,
+     file conventions, and terminology unique to this repo.
+  3. Write a full `context.md` to `.agent-docs/context.md` following the format — with a
+     title, description, `## Language` section, and all relevant domain terms with tight
+     definitions and avoid-lists.
+  4. Report: "Created `.agent-docs/context.md` from codebase analysis."
+
+- **Review and improve sub-path** (file exists):
+  1. Read `CONTEXT-FORMAT.md` from this skill's directory.
+  2. Read the existing `.agent-docs/context.md`.
+  3. Audit against the rules: missing terms, weak definitions (more than two sentences),
+     missing avoid-lists, general programming concepts that do not belong, ungrouped clusters.
+  4. If shortcomings are found: write the improved file and report: "Improved
+     `.agent-docs/context.md` — {brief summary of changes}."
+  5. If no shortcomings are found: report "`.agent-docs/context.md` reviewed — no
+     improvements needed." and continue to Step 7 without writing.
+
+`CONTEXT-FORMAT.md` already lives in `init-agent-docs/` alongside `SKILL.md` and
+`REFERENCE.md` — no new files are needed.
+
+## Testing Decisions
+
+No executable code changes. Verification is by inspection of the updated skill files:
+
+- **Step 4 routing**: read `SKILL.md` and `REFERENCE.md` — the "skip to Step 7" branch for
+  an existing `context.md` must be absent; the route to Step 6 must be present.
+- **Step 5 routing**: read `REFERENCE.md` — the "skip to Step 7" branch after a successful
+  move must be absent; the continue-to-Step-6 instruction must be present.
+- **Step 6 generate sub-path**: read `REFERENCE.md` — must reference `CONTEXT-FORMAT.md`,
+  must instruct codebase reading, must not reference `CONTEXT-TEMPLATE.md`.
+- **Step 6 review sub-path**: read `REFERENCE.md` — must include audit criteria from
+  `CONTEXT-FORMAT.md` rules, must include both "improved" and "no improvements needed"
+  report variants.
+- **`CONTEXT-TEMPLATE.md` reference absent**: grep both files — must produce zero hits.
+
+## Out of Scope
+
+- Changes to any other step (Steps 1–3, 7–10)
+- Changes to `CONTEXT-FORMAT.md` itself
+- Changes to other skills
+- Generating or modifying an actual `context.md` for this skills repo (that is a runtime
+  output of the skill, not part of the skill definition)
+
+## Further Notes
+
+`CONTEXT-FORMAT.md` already exists in `init-agent-docs/` as of the trigger for this work.
+The `CONTEXT-TEMPLATE.md` reference in the current files is simply wrong — there is no such
+file and there never will be. The fix replaces the broken reference entirely rather than
+creating a template file to satisfy it.
+
+The SKILL.md overview only needs to update the Step 4 and Step 6 summary lines — the detail
+lives in REFERENCE.md. Both files must be updated in sync.

--- a/.agent-docs/specs/chore/init-agent-docs-context-bootstrap.md
+++ b/.agent-docs/specs/chore/init-agent-docs-context-bootstrap.md
@@ -80,8 +80,8 @@ Replace the single "write CONTEXT-TEMPLATE.md verbatim" instruction with two sub
   5. If no shortcomings are found: report "`.agent-docs/context.md` reviewed — no
      improvements needed." and continue to Step 7 without writing.
 
-`CONTEXT-FORMAT.md` already lives in `init-agent-docs/` alongside `SKILL.md` and
-`REFERENCE.md` — no new files are needed.
+`CONTEXT-FORMAT.md` is added to `init-agent-docs/` alongside `SKILL.md` and `REFERENCE.md`
+as part of this change. The obsolete `CONTEXT-TEMPLATE.md` is removed.
 
 ## Testing Decisions
 
@@ -108,10 +108,9 @@ No executable code changes. Verification is by inspection of the updated skill f
 
 ## Further Notes
 
-`CONTEXT-FORMAT.md` already exists in `init-agent-docs/` as of the trigger for this work.
-The `CONTEXT-TEMPLATE.md` reference in the current files is simply wrong — there is no such
-file and there never will be. The fix replaces the broken reference entirely rather than
-creating a template file to satisfy it.
+`CONTEXT-FORMAT.md` is introduced in this PR. The `CONTEXT-TEMPLATE.md` reference in the
+original files was simply wrong — there was no such file. The fix replaces the broken
+reference entirely and adds the format spec that the skill now reads.
 
 The SKILL.md overview only needs to update the Step 4 and Step 6 summary lines — the detail
 lives in REFERENCE.md. Both files must be updated in sync.

--- a/init-agent-docs/CONTEXT-FORMAT.md
+++ b/init-agent-docs/CONTEXT-FORMAT.md
@@ -1,0 +1,60 @@
+# CONTEXT.md Format
+
+## Structure
+
+```md
+# {Context Name}
+
+{One or two sentence description of what this context is and why it exists.}
+
+## Language
+
+**Order**:
+{A one or two sentence description of the term}
+_Avoid_: Purchase, transaction
+
+**Invoice**:
+A request for payment sent to a customer after delivery.
+_Avoid_: Bill, payment request
+
+**Customer**:
+A person or organization that places orders.
+_Avoid_: Client, buyer, account
+```
+
+## Rules
+
+- **Be opinionated.** When multiple words exist for the same concept, pick the best one and list the others under `_Avoid_`.
+- **Keep definitions tight.** One or two sentences max. Define what it IS, not what it does.
+- **Only include terms specific to this project's context.** General programming concepts (timeouts, error types, utility patterns) don't belong even if the project uses them extensively. Before adding a term, ask: is this a concept unique to this context, or a general programming concept? Only the former belongs.
+- **Group terms under subheadings** when natural clusters emerge. If all terms belong to a single cohesive area, a flat list is fine.
+
+## Single vs multi-context repos
+
+**Single context (most repos):** One `CONTEXT.md` at the repo root.
+
+**Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
+
+```md
+# Context Map
+
+## Contexts
+
+- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
+- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+
+## Relationships
+
+- **Ordering → Fulfillment**: Ordering emits `OrderPlaced` events; Fulfillment consumes them to start picking
+- **Fulfillment → Billing**: Fulfillment emits `ShipmentDispatched` events; Billing consumes them to generate invoices
+- **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
+```
+
+The skill infers which structure applies:
+
+- If `CONTEXT-MAP.md` exists, read it to find contexts
+- If only a root `CONTEXT.md` exists, single context
+- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+
+When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.

--- a/init-agent-docs/CONTEXT-FORMAT.md
+++ b/init-agent-docs/CONTEXT-FORMAT.md
@@ -31,7 +31,7 @@ _Avoid_: Client, buyer, account
 
 ## Single vs multi-context repos
 
-**Single context (most repos):** One `CONTEXT.md` at the repo root.
+**Single context (most repos):** One `context.md` at the appropriate location (e.g. `.agent-docs/context.md`).
 
 **Multiple contexts:** A `CONTEXT-MAP.md` at the repo root lists the contexts, where they live, and how they relate to each other:
 
@@ -40,9 +40,9 @@ _Avoid_: Client, buyer, account
 
 ## Contexts
 
-- [Ordering](./src/ordering/CONTEXT.md) — receives and tracks customer orders
-- [Billing](./src/billing/CONTEXT.md) — generates invoices and processes payments
-- [Fulfillment](./src/fulfillment/CONTEXT.md) — manages warehouse picking and shipping
+- [Ordering](./src/ordering/context.md) — receives and tracks customer orders
+- [Billing](./src/billing/context.md) — generates invoices and processes payments
+- [Fulfillment](./src/fulfillment/context.md) — manages warehouse picking and shipping
 
 ## Relationships
 

--- a/init-agent-docs/CONTEXT-FORMAT.md
+++ b/init-agent-docs/CONTEXT-FORMAT.md
@@ -51,10 +51,10 @@ _Avoid_: Client, buyer, account
 - **Ordering ↔ Billing**: Shared types for `CustomerId` and `Money`
 ```
 
-The skill infers which structure applies:
+Choose the structure that fits the repository:
 
-- If `CONTEXT-MAP.md` exists, read it to find contexts
-- If only a root `CONTEXT.md` exists, single context
-- If neither exists, create a root `CONTEXT.md` lazily when the first term is resolved
+- Single context: create one `context.md` at the appropriate location (e.g. `.agent-docs/context.md`)
+- Multiple contexts: create a `CONTEXT-MAP.md` at the repo root listing each context and its location
 
-When multiple contexts exist, infer which one the current topic relates to. If unclear, ask.
+When working within a multi-context repo, infer which context the current topic relates to.
+If it is unclear, ask.

--- a/init-agent-docs/CONTEXT-TEMPLATE.md
+++ b/init-agent-docs/CONTEXT-TEMPLATE.md
@@ -1,9 +1,0 @@
-# Project Context
-
-One or two sentences describing what this project does and why this context exists.
-
-## Language
-
-**Term**:
-A one- or two-sentence definition. Define what it IS, not what it does.
-_Avoid_: Other words for the same concept

--- a/init-agent-docs/REFERENCE.md
+++ b/init-agent-docs/REFERENCE.md
@@ -159,8 +159,9 @@ This step has two sub-paths depending on whether a `context.md` was found in Ste
 
 ### Generate sub-path (no context.md found after Steps 4–5)
 
-1. Read `CONTEXT-FORMAT.md` from this skill's directory (alongside this `REFERENCE.md`) to
-   understand the required structure and rules.
+1. Read the **Structure** and **Rules** sections of `CONTEXT-FORMAT.md` from this skill's
+   directory (alongside this `REFERENCE.md`). Do not apply the "Single vs multi-context
+   repos" section — this skill always bootstraps a single-context `.agent-docs/context.md`.
 2. Read the codebase to identify domain-specific concepts — the terminology, workflow names,
    file conventions, and concepts unique to this repository. Focus on terms that a new
    contributor would need to understand to work in this codebase, not general programming
@@ -281,10 +282,10 @@ Example (fresh repo with no prior agent docs):
 ```text
 init-agent-docs complete:
   - no agent-docs/ layout to migrate — skipped
-  - created .agent-docs/agent.md
-  - created .agent-docs/context.md from codebase analysis
+  - Created `.agent-docs/agent.md`.
+  - Created `.agent-docs/context.md` from codebase analysis.
   - no ADRs found — skipped
-  - created CLAUDE.md with Agent Standards reference
+  - Created `CLAUDE.md` with Agent Standards reference.
 ```
 
 Example (existing repo where context.md needed improvement):
@@ -292,11 +293,11 @@ Example (existing repo where context.md needed improvement):
 ```text
 init-agent-docs complete:
   - no agent-docs/ layout to migrate — skipped
-  - .agent-docs/agent.md already exists — skipped
-  - .agent-docs/context.md found — proceeding to review
-  - improved .agent-docs/context.md — tightened 2 definitions, added avoid-lists for 3 terms
+  - `.agent-docs/agent.md` already exists — skipping.
+  - `.agent-docs/context.md` found — proceeding to review.
+  - Improved `.agent-docs/context.md` — tightened 2 definitions, added avoid-lists for 3 terms.
   - no ADRs found — skipped
-  - CLAUDE.md already references .agent-docs/agent.md — skipped
+  - `CLAUDE.md` already references `.agent-docs/agent.md` — skipping.
 ```
 
 Or if nothing needed doing:
@@ -304,8 +305,8 @@ Or if nothing needed doing:
 ```text
 init-agent-docs complete (nothing to do):
   - no agent-docs/ layout to migrate — skipped
-  - .agent-docs/agent.md already exists — skipped
-  - .agent-docs/context.md reviewed — no improvements needed
+  - `.agent-docs/agent.md` already exists — skipping.
+  - `.agent-docs/context.md` reviewed — no improvements needed.
   - no ADRs found — skipped
-  - CLAUDE.md already references .agent-docs/agent.md — skipped
+  - `CLAUDE.md` already references `.agent-docs/agent.md` — skipping.
 ```

--- a/init-agent-docs/REFERENCE.md
+++ b/init-agent-docs/REFERENCE.md
@@ -181,8 +181,10 @@ This step has two sub-paths depending on whether a `context.md` was found in Ste
 
 1. Read `CONTEXT-FORMAT.md` from this skill's directory.
 2. Read the existing `.agent-docs/context.md`.
-3. Audit the file against every rule defined in `CONTEXT-FORMAT.md`. Apply each rule in turn
-   and identify any shortcomings — do not rely on memory; read the rules from the file.
+3. Audit the file against the **Structure** and **Rules** sections of `CONTEXT-FORMAT.md`
+   (the single-context format). Apply each rule in turn and identify any shortcomings — do
+   not rely on memory; read the rules from the file. Do not apply the "Single vs multi-context
+   repos" section — this skill always bootstraps a single-context `context.md`.
 4. If shortcomings are found:
    - Write the improved file to `.agent-docs/context.md`.
      If writing fails, report the error clearly and skip to Step 7.
@@ -274,16 +276,27 @@ If `CLAUDE.md` existed and was appended to:
 ## Step 10 — Summary
 
 Report a brief summary of every action taken and every step skipped with a reason.
-Example (fresh repo with a legacy agent-docs/ layout to migrate):
+Example (fresh repo with no prior agent docs):
 
 ```text
 init-agent-docs complete:
-  - Migrated agent-docs/agent.md to .agent-docs/agent.md
-  - Migrated agent-docs/context.md to .agent-docs/context.md
-  - .agent-docs/agent.md already exists — skipped
-  - .agent-docs/context.md already exists — skipped
+  - no agent-docs/ layout to migrate — skipped
+  - created .agent-docs/agent.md
+  - created .agent-docs/context.md from codebase analysis
   - no ADRs found — skipped
-  - Migrated CLAUDE.md reference from agent-docs/agent.md to .agent-docs/agent.md
+  - created CLAUDE.md with Agent Standards reference
+```
+
+Example (existing repo where context.md needed improvement):
+
+```text
+init-agent-docs complete:
+  - no agent-docs/ layout to migrate — skipped
+  - .agent-docs/agent.md already exists — skipped
+  - .agent-docs/context.md found — proceeding to review
+  - improved .agent-docs/context.md — tightened 2 definitions, added avoid-lists for 3 terms
+  - no ADRs found — skipped
+  - CLAUDE.md already references .agent-docs/agent.md — skipped
 ```
 
 Or if nothing needed doing:
@@ -292,7 +305,7 @@ Or if nothing needed doing:
 init-agent-docs complete (nothing to do):
   - no agent-docs/ layout to migrate — skipped
   - .agent-docs/agent.md already exists — skipped
-  - .agent-docs/context.md already exists — skipped
+  - .agent-docs/context.md reviewed — no improvements needed
   - no ADRs found — skipped
   - CLAUDE.md already references .agent-docs/agent.md — skipped
 ```

--- a/init-agent-docs/REFERENCE.md
+++ b/init-agent-docs/REFERENCE.md
@@ -110,8 +110,8 @@ Check whether `.agent-docs/context.md` already exists in the current repository.
 
 If it exists:
 
-- Report: "`.agent-docs/context.md` already exists — skipping."
-- Skip to Step 7 (ADR migration still runs).
+- Report: "`.agent-docs/context.md` found — proceeding to review."
+- Continue to Step 6 (review sub-path).
 
 If it does not exist, continue to Step 5.
 
@@ -149,25 +149,52 @@ Collect all matches found.
 If both steps succeed:
 
 - Report: "Moved `<source path>` to `.agent-docs/context.md`."
-- Skip to Step 7.
+- Continue to Step 6 (review sub-path).
 
 **If no files are found**, continue to Step 6.
 
-## Step 6 — Create context.md from template
+## Step 6 — Bootstrap or review context.md
 
-Read the full contents of this skill's `CONTEXT-TEMPLATE.md` file (located in the same
-directory as this `SKILL.md`).
+This step has two sub-paths depending on whether a `context.md` was found in Steps 4–5.
 
-Write those contents verbatim to `.agent-docs/context.md` in the current repository.
+### Generate sub-path (no context.md found after Steps 4–5)
 
-If writing fails for any reason (permissions, disk space, etc.):
+1. Read `CONTEXT-FORMAT.md` from this skill's directory (alongside this `REFERENCE.md`) to
+   understand the required structure and rules.
+2. Read the codebase to identify domain-specific concepts — the terminology, workflow names,
+   file conventions, and concepts unique to this repository. Focus on terms that a new
+   contributor would need to understand to work in this codebase, not general programming
+   concepts.
+3. Write a full `context.md` to `.agent-docs/context.md` following the format defined in
+   `CONTEXT-FORMAT.md`:
+   - A `# {Context Name}` heading using the repository name or domain name.
+   - A one- or two-sentence description of what the context is and why it exists.
+   - A `## Language` section listing all domain-specific terms found, each with a tight
+     one- or two-sentence definition and an `_Avoid_` line listing synonyms to reject.
+   - Subheadings grouping terms when natural clusters emerge.
 
-- Report the error clearly.
-- Skip to Step 7.
+   If writing fails for any reason, report the error clearly and skip to Step 7.
 
-If writing succeeds:
+4. Report: "Created `.agent-docs/context.md` from codebase analysis."
 
-- Report: "Created `.agent-docs/context.md` from template."
+### Review and improve sub-path (context.md exists or was just moved)
+
+1. Read `CONTEXT-FORMAT.md` from this skill's directory.
+2. Read the existing `.agent-docs/context.md`.
+3. Audit the file against the rules in `CONTEXT-FORMAT.md`:
+   - Are definitions longer than two sentences? (tighten them)
+   - Are any terms missing an `_Avoid_` line when synonyms clearly exist?
+   - Do any definitions describe what a concept *does* rather than what it *is*?
+   - Are there general programming concepts that do not belong (not specific to this domain)?
+   - Are there term clusters that would benefit from a subheading but are currently ungrouped?
+   - Are there obvious domain concepts visible in the codebase that are missing from the glossary?
+4. If shortcomings are found:
+   - Write the improved file to `.agent-docs/context.md`.
+     If writing fails, report the error clearly and skip to Step 7.
+   - Report: "Improved `.agent-docs/context.md` — `<brief summary of changes>`."
+5. If no shortcomings are found:
+   - Report: "`.agent-docs/context.md` reviewed — no improvements needed."
+   - Continue to Step 7 without writing.
 
 ## Step 7 — Migrate ADR files
 

--- a/init-agent-docs/REFERENCE.md
+++ b/init-agent-docs/REFERENCE.md
@@ -181,13 +181,8 @@ This step has two sub-paths depending on whether a `context.md` was found in Ste
 
 1. Read `CONTEXT-FORMAT.md` from this skill's directory.
 2. Read the existing `.agent-docs/context.md`.
-3. Audit the file against the rules in `CONTEXT-FORMAT.md`:
-   - Are definitions longer than two sentences? (tighten them)
-   - Are any terms missing an `_Avoid_` line when synonyms clearly exist?
-   - Do any definitions describe what a concept *does* rather than what it *is*?
-   - Are there general programming concepts that do not belong (not specific to this domain)?
-   - Are there term clusters that would benefit from a subheading but are currently ungrouped?
-   - Are there obvious domain concepts visible in the codebase that are missing from the glossary?
+3. Audit the file against every rule defined in `CONTEXT-FORMAT.md`. Apply each rule in turn
+   and identify any shortcomings — do not rely on memory; read the rules from the file.
 4. If shortcomings are found:
    - Write the improved file to `.agent-docs/context.md`.
      If writing fails, report the error clearly and skip to Step 7.

--- a/init-agent-docs/SKILL.md
+++ b/init-agent-docs/SKILL.md
@@ -6,8 +6,8 @@ description: Bootstraps AI agent documentation in the current repository — mig
 # init-agent-docs
 
 Bootstraps `.agent-docs/agent.md`, `.agent-docs/context.md`, and a `CLAUDE.md` reference in
-the current repository. On each run, reviews an existing `context.md` against the format
-rules and improves it only where needed.
+the current repository. When `.agent-docs/context.md` is present or moved into place, reviews
+it against the format rules and improves it only where needed.
 
 > **Assumption**: this skill must be invoked from the repository root. It writes paths
 > relative to the current working directory.

--- a/init-agent-docs/SKILL.md
+++ b/init-agent-docs/SKILL.md
@@ -6,8 +6,8 @@ description: Bootstraps AI agent documentation in the current repository — mig
 # init-agent-docs
 
 Bootstraps `.agent-docs/agent.md`, `.agent-docs/context.md`, and a `CLAUDE.md` reference in
-the current repository. On each run, always reviews and improves an existing `context.md`
-against the format rules.
+the current repository. On each run, reviews an existing `context.md` against the format
+rules and improves it only where needed.
 
 > **Assumption**: this skill must be invoked from the repository root. It writes paths
 > relative to the current working directory.
@@ -19,9 +19,9 @@ See [REFERENCE.md](REFERENCE.md) for the full per-step detail.
 1. **Migrate existing agent-docs/ layout** — if the legacy `agent-docs/` directory exists, move `agent.md`, `context.md`, and `adr/` to `.agent-docs/`; warn about any unrecognised items.
 2. **Check for existing agent.md** — if `.agent-docs/agent.md` already exists, skip to Step 4.
 3. **Create agent.md** — write `AGENT-TEMPLATE.md` verbatim to `.agent-docs/agent.md`.
-4. **Check for existing context.md** — if `.agent-docs/context.md` already exists, continue to Step 6 (review sub-path).
-5. **Search for context.md to move** — look in the repo root and `docs/`; move it if exactly one is found (then continue to Step 6 review sub-path); report ambiguity if multiple found.
-6. **Bootstrap or review context.md** — two sub-paths: if no `context.md` was found, read `CONTEXT-FORMAT.md` and the codebase to generate a full domain glossary; if a file exists (found in place or just moved), review and improve it against `CONTEXT-FORMAT.md` rules, or report "no improvements needed" if already compliant.
+4. **Check for existing context.md** — if `.agent-docs/context.md` already exists, go to Step 6.
+5. **Search for context.md to move** — look in the repo root and `docs/`; move if exactly one found, then go to Step 6; report ambiguity and skip to Step 7 if multiple found.
+6. **Bootstrap or review context.md** — generate a full domain glossary from the codebase if no file exists; otherwise review and improve the existing file against `CONTEXT-FORMAT.md`, or report "no improvements needed" if already compliant.
 7. **Migrate ADR files** — search `docs/`, `docs/adr/`, `agent-docs/docs/adr/`, and `.agent-docs/docs/adr/` for ADR files matching `[0-9]*-*.md`; move them to `.agent-docs/adr/`, resolving conflicts by git date.
 8. **Check CLAUDE.md** — if `CLAUDE.md` already references `.agent-docs/agent.md`, skip to Step 10; if it references the old path, update it.
 9. **Create or append CLAUDE.md** — append the Agent Standards reference block to `CLAUDE.md` (create if missing).

--- a/init-agent-docs/SKILL.md
+++ b/init-agent-docs/SKILL.md
@@ -6,8 +6,8 @@ description: Bootstraps AI agent documentation in the current repository — mig
 # init-agent-docs
 
 Bootstraps `.agent-docs/agent.md`, `.agent-docs/context.md`, and a `CLAUDE.md` reference in
-the current repository. Safe to run more than once — skips any step where the output already
-exists.
+the current repository. On each run, always reviews and improves an existing `context.md`
+against the format rules.
 
 > **Assumption**: this skill must be invoked from the repository root. It writes paths
 > relative to the current working directory.
@@ -19,9 +19,9 @@ See [REFERENCE.md](REFERENCE.md) for the full per-step detail.
 1. **Migrate existing agent-docs/ layout** — if the legacy `agent-docs/` directory exists, move `agent.md`, `context.md`, and `adr/` to `.agent-docs/`; warn about any unrecognised items.
 2. **Check for existing agent.md** — if `.agent-docs/agent.md` already exists, skip to Step 4.
 3. **Create agent.md** — write `AGENT-TEMPLATE.md` verbatim to `.agent-docs/agent.md`.
-4. **Check for existing context.md** — if `.agent-docs/context.md` already exists, skip to Step 7.
-5. **Search for context.md to move** — look in the repo root and `docs/`; move it if exactly one is found; report ambiguity if multiple found.
-6. **Create context.md from template** — if no existing `context.md` was found, write `CONTEXT-TEMPLATE.md` verbatim to `.agent-docs/context.md`.
+4. **Check for existing context.md** — if `.agent-docs/context.md` already exists, continue to Step 6 (review sub-path).
+5. **Search for context.md to move** — look in the repo root and `docs/`; move it if exactly one is found (then continue to Step 6 review sub-path); report ambiguity if multiple found.
+6. **Bootstrap or review context.md** — two sub-paths: if no `context.md` was found, read `CONTEXT-FORMAT.md` and the codebase to generate a full domain glossary; if a file exists (found in place or just moved), review and improve it against `CONTEXT-FORMAT.md` rules, or report "no improvements needed" if already compliant.
 7. **Migrate ADR files** — search `docs/`, `docs/adr/`, `agent-docs/docs/adr/`, and `.agent-docs/docs/adr/` for ADR files matching `[0-9]*-*.md`; move them to `.agent-docs/adr/`, resolving conflicts by git date.
 8. **Check CLAUDE.md** — if `CLAUDE.md` already references `.agent-docs/agent.md`, skip to Step 10; if it references the old path, update it.
 9. **Create or append CLAUDE.md** — append the Agent Standards reference block to `CLAUDE.md` (create if missing).


### PR DESCRIPTION
## Summary

- Replaces broken `CONTEXT-TEMPLATE.md` verbatim-copy in Step 6 with two sub-paths: **generate** (reads codebase + `CONTEXT-FORMAT.md`, writes a full domain glossary) and **review-and-improve** (audits existing file against format rules, improves only where needed)
- Fixes Step 4 to route to Step 6 review sub-path instead of skipping to Step 7 when `context.md` already exists
- Fixes Step 5 to route to Step 6 review sub-path after a successful file move, instead of skipping to Step 7
- Adds `init-agent-docs/CONTEXT-FORMAT.md` (the format spec the skill now references), removes `init-agent-docs/CONTEXT-TEMPLATE.md` (the broken reference), removes `agent-docs/context.md` placeholder
- Updates Step 10 summary examples to reflect the new behaviour

Closes #24

## Test plan

- [ ] `SKILL.md` Step 4 routes to Step 6, not Step 7, when `context.md` exists
- [ ] `REFERENCE.md` Step 4 routes to Step 6, not Step 7, when `context.md` exists
- [ ] `REFERENCE.md` Step 5 continues to Step 6 after successful file move (not Step 7)
- [ ] `REFERENCE.md` Step 6 generate sub-path reads `CONTEXT-FORMAT.md` and the codebase before writing
- [ ] `REFERENCE.md` Step 6 review sub-path audits against Structure + Rules sections of `CONTEXT-FORMAT.md`, with both "improved" and "no improvements needed" report variants
- [ ] `SKILL.md` Step 6 one-liner reflects both sub-paths
- [ ] Neither `SKILL.md` nor `REFERENCE.md` references `CONTEXT-TEMPLATE.md` (zero grep hits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)