### PR TITLE
remove sub-agent from implement skill

### DIFF
--- a/.agent-docs/issues/chore/fix-skill-checklist-compliance.md
+++ b/.agent-docs/issues/chore/fix-skill-checklist-compliance.md
@@ -1,0 +1,181 @@
+# Issues: chore/fix-skill-checklist-compliance
+
+<!-- markdownlint-configure-file {"MD024": {"siblings_only": true}} -->
+
+> Merged and closed.
+
+## Fix P3 and P1 description issues (pr-cleanup, write-spec, bdd) — #14
+
+**Blocked by**: None
+
+**User stories**: 1, 3, 5
+
+### What to build
+
+Three small targeted edits with no extraction needed:
+
+- Remove the redundant third sentence "This skill should be used whenever code is modified." from the bdd frontmatter description.
+- Append "Use when a PR has been merged and issues need closing, or when invoked by /implement after the merge confirmation loop." to the pr-cleanup frontmatter description.
+- Delete the provisional note block from write-spec/SKILL.md: the `> **Note**: ...candidate for restructuring in the future...` paragraph.
+
+### Acceptance criteria
+
+- [x] `behaviour-driven-development/SKILL.md` description has exactly two sentences (no third sentence about code modification)
+- [x] `pr-cleanup/SKILL.md` description ends with the specified "Use when" sentence
+- [x] `write-spec/SKILL.md` contains no mention of "candidate for restructuring" or "in the future"
+
+---
+
+## Add examples to design and grill — #15
+
+**Blocked by**: None
+
+**User stories**: 4
+
+### What to build
+
+Add at least one concrete example to each of two skills:
+
+- `design/SKILL.md`: insert a one-line sample Phase 1 question and recommended answer inside the Phase 1 section.
+- `grill/SKILL.md`: add a see-also note pointing to `design/SKILL.md` for examples, or add a one-line illustrative question.
+
+### Acceptance criteria
+
+- [x] `design/SKILL.md` contains at least one concrete example of a grilling question with a recommended answer
+- [x] `grill/SKILL.md` contains either a see-also reference to `design/SKILL.md` or a one-line example question
+- [x] Both files remain under 100 lines
+
+---
+
+## Extract init-agent-docs step prose to REFERENCE.md — #16
+
+**Blocked by**: None
+
+**User stories**: 2, 6
+
+### What to build
+
+`init-agent-docs/SKILL.md` is 288 lines — far over the 100-line limit. Extract the detailed per-step migration prose (the body of Steps 1–7) to a new `init-agent-docs/REFERENCE.md`. Keep in SKILL.md: the intro paragraph, a numbered step-overview list (one line per step), and a link to REFERENCE.md for full detail.
+
+### Acceptance criteria
+
+- [x] `init-agent-docs/SKILL.md` is under 100 lines
+- [x] `init-agent-docs/REFERENCE.md` exists and contains the full step detail
+- [x] SKILL.md links to REFERENCE.md
+- [x] All step names are still represented (as one-liners) in SKILL.md
+
+---
+
+## Extract bdd workflow steps to WORKFLOW.md — #17
+
+**Blocked by**: None
+
+**User stories**: 2, 6
+
+### What to build
+
+`behaviour-driven-development/SKILL.md` is 164 lines. Extract the Workflow section (Steps 0–5 and the Checklist Per Cycle) to a new `behaviour-driven-development/WORKFLOW.md`. Keep in SKILL.md: the Philosophy section, the Scenarios: Given-When-Then section, the Anti-Pattern: Horizontal Slices section, and a brief "Workflow" pointer linking to WORKFLOW.md.
+
+### Acceptance criteria
+
+- [x] `behaviour-driven-development/SKILL.md` is under 100 lines
+- [x] `behaviour-driven-development/WORKFLOW.md` exists and contains the workflow steps
+- [x] SKILL.md links to WORKFLOW.md
+- [x] The three core conceptual sections (Philosophy, Scenarios, Anti-Pattern) remain in SKILL.md
+
+---
+
+## Collapse address-copilot-comments Steps 3–7 to REFERENCE.md links — #18
+
+**Blocked by**: None
+
+**User stories**: 2, 6
+
+### What to build
+
+`address-copilot-comments/SKILL.md` is 158 lines and already has a REFERENCE.md. Collapse the inline body of Steps 3–7 to one-liner summaries with links to the corresponding REFERENCE.md anchors. The Loop at a glance diagram and Steps 0–2 stay in full.
+
+### Acceptance criteria
+
+- [x] `address-copilot-comments/SKILL.md` is under 100 lines
+- [x] Steps 3–7 each have a one-liner summary and a link to REFERENCE.md
+- [x] REFERENCE.md is unchanged (or only minimally adjusted for anchor names if needed)
+- [x] Loop at a glance and Steps 0–2 remain intact in full
+
+---
+
+## Extract branch-hygiene validation detail to REFERENCE.md — #19
+
+**Blocked by**: None
+
+**User stories**: 2, 6
+
+### What to build
+
+`branch-hygiene/SKILL.md` is 134 lines. Move the validation tables (branch classification table in Step 2, prefix-validation table in Step 4) and the mismatch resolution logic (Steps 5–6 body) to a new `branch-hygiene/REFERENCE.md`. Keep in SKILL.md: the two-mode overview, step headers with one-liner summaries, and links to REFERENCE.md.
+
+### Acceptance criteria
+
+- [x] `branch-hygiene/SKILL.md` is under 100 lines
+- [x] `branch-hygiene/REFERENCE.md` exists and contains the tables and resolution logic
+- [x] SKILL.md links to REFERENCE.md
+- [x] Two-mode overview and all step headers remain in SKILL.md
+
+---
+
+## Extract create-issues CLI commands to REFERENCE.md — #20
+
+**Blocked by**: None
+
+**User stories**: 2, 6
+
+### What to build
+
+`create-issues/SKILL.md` is 115 lines. Move the full GitHub CLI command blocks and the issue template body (the content of Steps 5–6) to a new `create-issues/REFERENCE.md`. Keep process steps as one-liner summaries in SKILL.md with a link to REFERENCE.md for the full commands and template.
+
+### Acceptance criteria
+
+- [x] `create-issues/SKILL.md` is under 100 lines
+- [x] `create-issues/REFERENCE.md` exists and contains the CLI commands and template body
+- [x] SKILL.md links to REFERENCE.md
+- [x] All six process steps are still represented (as one-liners) in SKILL.md
+
+---
+
+## Extract implement workflow to WORKFLOW.md — #21
+
+**Blocked by**: None
+
+**User stories**: 2, 6
+
+### What to build
+
+`implement/SKILL.md` is 118 lines. Extract the embedded "Implementation workflow" block (the full Step 0–8 sub-agent instructions) to a new `implement/WORKFLOW.md`. SKILL.md keeps three steps: Step 1 (capture trigger context), Step 2 (spawn sub-agent with a prompt that references WORKFLOW.md), Step 3 (monitor).
+
+### Acceptance criteria
+
+- [x] `implement/SKILL.md` is under 100 lines
+- [x] `implement/WORKFLOW.md` exists and contains the full Step 0–8 workflow
+- [x] SKILL.md Step 2 instructs the spawned sub-agent to reference WORKFLOW.md
+- [x] All three SKILL.md steps (capture, spawn, monitor) remain
+
+---
+
+## Extract create-a-skill reference sections to REFERENCE.md — #22
+
+**Blocked by**: None
+
+**User stories**: 2, 6
+
+### What to build
+
+`create-a-skill/SKILL.md` is 117 lines. Move the "Description Requirements" section and the "Review Checklist" section to a new `create-a-skill/REFERENCE.md`. Keep in SKILL.md: the Process section, the Skill Structure section, and links to REFERENCE.md for description requirements and the checklist.
+
+### Acceptance criteria
+
+- [x] `create-a-skill/SKILL.md` is under 100 lines
+- [x] `create-a-skill/REFERENCE.md` exists and contains Description Requirements and Review Checklist
+- [x] SKILL.md links to REFERENCE.md
+- [x] Process and Skill Structure sections remain in SKILL.md
+
+---

--- a/.agent-docs/issues/chore/init-agent-docs-context-bootstrap.md
+++ b/.agent-docs/issues/chore/init-agent-docs-context-bootstrap.md
@@ -1,5 +1,7 @@
 # Issues: chore/init-agent-docs-context-bootstrap
 
+> Merged and closed.
+
 ## Fix init-agent-docs context bootstrap (Steps 4, 5, 6)
 
 **Blocked by**: None
@@ -28,12 +30,12 @@ Three step changes, two files:
 
 ### Acceptance criteria
 
-- [ ] `SKILL.md` Step 4 no longer says "skip to Step 7" when `context.md` exists; it routes to Step 6.
-- [ ] `REFERENCE.md` Step 4 no longer says "skip to Step 7" when `context.md` exists; it routes to Step 6.
-- [ ] `REFERENCE.md` Step 5 no longer says "skip to Step 7" after a successful file move; it continues to Step 6.
-- [ ] `REFERENCE.md` Step 6 defines a **generate** sub-path that reads `CONTEXT-FORMAT.md` and the codebase before writing `context.md`.
-- [ ] `REFERENCE.md` Step 6 defines a **review and improve** sub-path with explicit audit criteria, an "improved" report variant, and a "no improvements needed" report variant.
-- [ ] `SKILL.md` Step 6 summary reflects the two sub-paths (generate vs review-and-improve).
-- [ ] Neither `SKILL.md` nor `REFERENCE.md` contains any reference to `CONTEXT-TEMPLATE.md`.
+- [x] `SKILL.md` Step 4 no longer says "skip to Step 7" when `context.md` exists; it routes to Step 6.
+- [x] `REFERENCE.md` Step 4 no longer says "skip to Step 7" when `context.md` exists; it routes to Step 6.
+- [x] `REFERENCE.md` Step 5 no longer says "skip to Step 7" after a successful file move; it continues to Step 6.
+- [x] `REFERENCE.md` Step 6 defines a **generate** sub-path that reads `CONTEXT-FORMAT.md` and the codebase before writing `context.md`.
+- [x] `REFERENCE.md` Step 6 defines a **review and improve** sub-path with explicit audit criteria, an "improved" report variant, and a "no improvements needed" report variant.
+- [x] `SKILL.md` Step 6 summary reflects the two sub-paths (generate vs review-and-improve).
+- [x] Neither `SKILL.md` nor `REFERENCE.md` contains any reference to `CONTEXT-TEMPLATE.md`.
 
 ---

--- a/.agent-docs/specs/chore/fix-skill-checklist-compliance.md
+++ b/.agent-docs/specs/chore/fix-skill-checklist-compliance.md
@@ -1,0 +1,67 @@
+# Fix Skill Checklist Compliance
+
+## Problem Statement
+
+Thirteen skills in the repository fail validation against the `create-a-skill` checklist. Twelve distinct issues span missing trigger sentences, oversized SKILL.md files, provisional language, absent examples, and a redundant description sentence. As a result, skill descriptions give the agent insufficient signal to select the right skill, and SKILL.md files are harder to read and maintain than the standard allows.
+
+## Solution
+
+Fix all 12 issues so every skill passes the `create-a-skill` checklist. Oversized SKILL.md files are reduced to under 100 lines by extracting detail into REFERENCE.md or WORKFLOW.md companions. Missing "Use when..." trigger sentences are added. Provisional and redundant language is removed. Concrete examples are added where required. All changes are documentation-only — no skill behaviour changes.
+
+## User Stories
+
+1. As a skill author, I want every skill description to include a "Use when..." trigger, so that the agent can reliably select the right skill from the installed list.
+2. As a skill reader, I want each SKILL.md to stay under 100 lines, so that the core instructions are easy to scan without scrolling through reference detail.
+3. As a skill author, I want provisional language removed from skill files, so that the documentation reads as stable and authoritative.
+4. As a skill user, I want concrete examples in design/SKILL.md and grill/SKILL.md, so that I understand what a grilling question looks like in practice.
+5. As a skill author, I want redundant trigger sentences removed from bdd's description, so that the description is concise and non-repetitive.
+6. As a skill maintainer, I want extracted detail in REFERENCE.md or WORKFLOW.md to be clearly linked from the parent SKILL.md, so that nothing is lost and readers can follow the reference chain.
+
+## Implementation Decisions
+
+Twelve targeted edits across thirteen skill files, grouped by issue type:
+
+**P1 — Missing "Use when" (hard criterion):**
+
+- `pr-cleanup/SKILL.md`: append "Use when a PR has been merged and issues need closing, or when invoked by /implement after the merge confirmation loop." to the frontmatter description.
+- `init-agent-docs/SKILL.md`: extract the per-step migration prose (Steps 1–7 body) to a new `init-agent-docs/REFERENCE.md`; replace with an intro paragraph, a step-overview list, and a link to REFERENCE.md. Target: under 100 lines.
+- `write-spec/SKILL.md`: delete the `> **Note**: ...candidate for restructuring...` block.
+- `design/SKILL.md`: add a one-line example of a grilling question and recommended answer inside the Phase 1 section.
+- `grill/SKILL.md`: add a see-also line pointing to `design/SKILL.md` for examples.
+
+**P2 — Over 100-line limit:**
+
+- `behaviour-driven-development/SKILL.md`: extract the Workflow section (Steps 0–5 and Checklist) to a new `behaviour-driven-development/WORKFLOW.md`; keep Philosophy and Scenarios sections in SKILL.md with a link to WORKFLOW.md.
+- `address-copilot-comments/SKILL.md`: collapse Steps 3–7 inline body to one-liner summaries with links to existing REFERENCE.md anchors.
+- `branch-hygiene/SKILL.md`: move validation tables (Steps 2, 4) and mismatch resolution logic (Steps 5–6) to a new `branch-hygiene/REFERENCE.md`; keep the two-mode overview and step headers in SKILL.md.
+- `create-issues/SKILL.md`: move GitHub CLI command blocks and issue template body (Steps 6–7) to a new `create-issues/REFERENCE.md`; keep process steps as one-liners.
+- `implement/SKILL.md`: extract the embedded "Implementation workflow" block (Steps 0–8) to a new `implement/WORKFLOW.md`; SKILL.md keeps Step 1 (capture context), Step 2 (spawn sub-agent referencing WORKFLOW.md), Step 3 (monitor).
+- `create-a-skill/SKILL.md`: move "Description Requirements" and "Review Checklist" sections to a new `create-a-skill/REFERENCE.md`; keep Process and Skill Structure sections in SKILL.md.
+
+**P3 — Redundant sentence:**
+
+- `behaviour-driven-development/SKILL.md` description: remove third sentence "This skill should be used whenever code is modified."
+
+All reference files are linked from their parent SKILL.md at the point where the extracted content would have appeared. Reference depth remains one level (SKILL.md → REFERENCE.md or WORKFLOW.md, never deeper).
+
+## Testing Decisions
+
+No runtime code is changed. Verification is by inspection:
+
+- Line count: `wc -l` on each edited SKILL.md must be under 100.
+- Trigger presence: grep for "Use when" in each skill's frontmatter description.
+- Provisional language: grep for "candidate for restructuring" or "in the future" — must be absent.
+- Example presence: read `design/SKILL.md` and `grill/SKILL.md` for at least one concrete example or see-also pointer.
+- Redundant sentence: grep for "This skill should be used whenever code is modified" — must be absent.
+- Reference links: each new REFERENCE.md / WORKFLOW.md must be linked from its parent SKILL.md.
+
+## Out of Scope
+
+- Changes to skill behaviour, logic, or step content (beyond moving text to companion files)
+- Adding new skills
+- Updating skills not listed in the 12 issues
+- Changes to scripts, templates, or non-SKILL.md files other than the new REFERENCE.md / WORKFLOW.md companions
+
+## Further Notes
+
+`behaviour-driven-development/SKILL.md` has two issues (P2 line-length and P3 redundant sentence) — both are addressed in a single edit pass. The `address-copilot-comments` skill already has a REFERENCE.md; the P2 fix collapses inline step detail to point at existing anchors rather than creating a new file.

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -61,7 +61,7 @@ Poll every 60 seconds (max 10 attempts) until unresolved Copilot thread count > 
 
 ## Step 4 — Decide and apply changes
 
-For each unresolved thread decide **Fix** or **Push back** (push back on `.agent-docs/` — Copilot is not a domain expert there); apply code changes; see the Address Each Comment section in [REFERENCE.md](REFERENCE.md) for fetch query and reply commands.
+For each unresolved thread decide **Fix** or **Push back** (push back on any file contained within `.agent-docs/` — Copilot is not a domain expert there); apply code changes; see the Address Each Comment section in [REFERENCE.md](REFERENCE.md) for fetch query and reply commands.
 
 ## Step 4b — Validate changes with code-review
 

--- a/implement/SKILL.md
+++ b/implement/SKILL.md
@@ -1,29 +1,8 @@
 ---
 name: implement
-description: Full implementation workflow — from change request to merged PR. Spawns a fresh sub-agent briefed with the trigger context to run the complete cycle: init-agent-docs → grill → branch → spec → issues → BDD per issue → code review → PR merge confirmation → cleanup. Use when the user wants to implement a feature, fix a bug, or make any change to the repository.
+description: Full implementation workflow — from change request to merged PR. Runs the complete cycle inline: init-agent-docs → grill → branch → spec → issues → BDD per issue → code review → PR merge confirmation → cleanup. Use when the user wants to implement a feature, fix a bug, or make any change to the repository.
 ---
 
 # Implement
 
-Capture the trigger context from the current conversation and spawn a fresh sub-agent to run the full implementation cycle.
-
-## Step 1 — Capture trigger context
-
-Before spawning, summarise from the current conversation:
-
-- What the user wants to change or build (one short paragraph)
-- Any constraints, preferences, or prior decisions already stated
-- The current branch (if the user mentioned it or it is evident from context)
-
-Keep the summary tight — enough to brief a fresh agent, not a transcript.
-
-## Step 2 — Spawn the implementation sub-agent
-
-Spawn a `claude` sub-agent with a self-contained prompt that includes:
-
-1. The trigger context summary from Step 1
-2. The full workflow from [WORKFLOW.md](WORKFLOW.md) (copy verbatim into the prompt)
-
-## Step 3 — Monitor
-
-The sub-agent runs the full workflow. You (the parent) have nothing further to do — the sub-agent will report when complete.
+Run the full implementation workflow inline in the current conversation, following [WORKFLOW.md](WORKFLOW.md) step by step.

--- a/implement/WORKFLOW.md
+++ b/implement/WORKFLOW.md
@@ -1,10 +1,10 @@
 # Implementation Workflow
 
-This is the full workflow embedded in the sub-agent prompt by [SKILL.md](SKILL.md) Step 2.
+This is the full implementation workflow run inline by [SKILL.md](SKILL.md).
 
 ---
 
-You have been spawned by `/implement` to carry out a full implementation cycle. The trigger context above tells you what to build. Work through the steps below in order.
+Work through the steps below in order.
 
 > **Prerequisite skills**: all skills referenced in this workflow live in this same skills
 > repo and are installed automatically via the post-commit sync hook:


### PR DESCRIPTION
## Summary

- Removes the sub-agent spawn from `implement/SKILL.md` — the full workflow now runs inline in the current conversation rather than briefing a fresh agent
- Updates `implement/WORKFLOW.md` preamble to reflect inline execution (removes sub-agent framing)
- Clarifies `address-copilot-comments/SKILL.md` push-back rule: "any file contained within `.agent-docs/`" (not just the directory itself)
- Adds issue and spec files for `chore/fix-skill-checklist-compliance`; updates issue file for `chore/init-agent-docs-context-bootstrap`

## Test plan

- [ ] Invoke `/implement` and confirm the workflow runs inline (no sub-agent spawned)
- [ ] Verify `implement/WORKFLOW.md` intro no longer references sub-agent framing
- [ ] Confirm `address-copilot-comments` push-back behaviour applies to all files under `.agent-docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)