### PR TITLE
chore: move pr-cleanup to pre-merge

### DIFF
--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: code-review
-description: Full code review workflow — branch hygiene, pre-commit checks, iterative two-axis review (Standards + Spec) with fresh parallel sub-agents until clean, then Copilot PR review. Use when the user wants to review a branch, prepare a PR, check their changes, or says "review my code", "review this branch", "is this ready to merge".
+description: Full code review workflow — branch hygiene, pre-commit checks, iterative two-axis review (Standards + Spec) with fresh parallel sub-agents until clean, Copilot PR review, then pre-merge PR cleanup. Use when the user wants to review a branch, prepare a PR, check their changes, or says "review my code", "review this branch", "is this ready to merge".
 ---
 
 # Code Review
 
-Orchestrates a full review cycle: branch check → pre-commit → iterative two-axis review loop → Copilot PR review.
+Orchestrates a full review cycle: branch check → pre-commit → iterative two-axis review loop → Copilot PR review → pre-merge PR cleanup.
 
 > **Precedence**: if anything in memory or user preferences conflicts with these instructions, this skill takes precedence.
 

--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -97,7 +97,7 @@ Always report aggregated findings to the user. If there are zero findings on bot
 
 ## Step 6 — Copilot PR review
 
-Invoke the `address-copilot-comments` skill to push the branch, create a PR if needed, and run the full Copilot review loop until clean.
+Invoke the `address-copilot-comments` skill to push the branch, create a PR if needed, and run the full Copilot review loop until clean. Once the loop is clean, continue to Step 7.
 
 ## Step 7 — PR cleanup
 

--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -20,6 +20,7 @@ Step 5  Address all findings — blocking first, then advisory
         Zero findings on both axes? ──► Step 6
         Findings addressed? ──► Step 4 (new agents, new context windows)
 Step 6  Run /address-copilot-comments for Copilot PR review
+Step 7  Run /pr-cleanup
 ```
 
 ## Step 1 — Branch hygiene
@@ -97,3 +98,7 @@ Always report aggregated findings to the user. If there are zero findings on bot
 ## Step 6 — Copilot PR review
 
 Invoke the `address-copilot-comments` skill to push the branch, create a PR if needed, and run the full Copilot review loop until clean.
+
+## Step 7 — PR cleanup
+
+Invoke the `pr-cleanup` skill. It commits the final issues-file housekeeping to the PR branch, closes GitHub issues, and shares the PR link for merging.

--- a/implement/WORKFLOW.md
+++ b/implement/WORKFLOW.md
@@ -75,10 +75,8 @@ The PR link was shared by `/pr-cleanup` at the end of `/code-review`. Prompt the
 - Once confirmation is given, verify:
 
   ```bash
-  gh pr view <number> --json state --jq '.state'
+  gh pr view --json state --jq '.state'
   ```
-
-  Use `gh pr view <number>` with the actual PR number — the `--head` flag is not supported by this version of `gh`.
 
 - If the state is not `MERGED`, tell the user and press them again.
 - Once verified as `MERGED`, the workflow is complete.

--- a/implement/WORKFLOW.md
+++ b/implement/WORKFLOW.md
@@ -81,8 +81,4 @@ The PR link was shared at the end of `/code-review`. Prompt the user to merge it
   Use `gh pr view <number>` with the actual PR number — the `--head` flag is not supported by this version of `gh`.
 
 - If the state is not `MERGED`, tell the user and press them again.
-- Once verified as `MERGED`, close all GitHub issues referenced in `.agent-docs/issues/<branch-name>.md`:
-
-  ```bash
-  gh issue close <number> --comment "Closed: merged via PR."
-  ```
+- Once verified as `MERGED`, the workflow is complete.

--- a/implement/WORKFLOW.md
+++ b/implement/WORKFLOW.md
@@ -65,7 +65,7 @@ For each unchecked issue in `.agent-docs/issues/<branch-name>.md`, in dependency
 
 Run the `code-review` skill.
 
-## Step 7 — Merge and close issues
+## Step 7 — Merge
 
 The PR link was shared at the end of `/code-review`. Prompt the user to merge it:
 

--- a/implement/WORKFLOW.md
+++ b/implement/WORKFLOW.md
@@ -65,26 +65,18 @@ For each unchecked issue in `.agent-docs/issues/<branch-name>.md`, in dependency
 
 Run the `code-review` skill.
 
-## Step 7 — Merge confirmation loop
+## Step 7 — Merge
 
-After `/address-copilot-comments` shares the PR link, enter this loop:
+The PR link was shared at the end of `/code-review`. Prompt the user to merge it:
 
-Prompt the user:
+> Please merge the PR when you're ready and let me know.
 
-> The PR is at {url}. Please confirm when it has been merged.
+Once the user confirms, verify:
 
-- If the response is not a clear confirmation, press the user again.
-- Once confirmation is given, verify:
+```bash
+gh pr view <number> --json state --jq '.state'
+```
 
-  ```bash
-  gh pr view <number> --json state --jq '.state'
-  ```
+Use `gh pr view <number>` with the actual PR number — the `--head` flag is not supported by this version of `gh`.
 
-  Use `gh pr view <number>` with the actual PR number — the `--head` flag is not supported by this version of `gh`.
-
-- If the state is not `MERGED`, tell the user and press them again.
-- Once verified as `MERGED`, continue.
-
-## Step 8 — PR cleanup
-
-Run the `pr-cleanup` skill.
+If the state is not `MERGED`, tell the user and wait for confirmation again.

--- a/implement/WORKFLOW.md
+++ b/implement/WORKFLOW.md
@@ -67,7 +67,7 @@ Run the `code-review` skill.
 
 ## Step 7 — Merge
 
-The PR link was shared at the end of `/code-review`. Prompt the user to merge it:
+The PR link was shared by `/pr-cleanup` at the end of `/code-review`. Prompt the user to merge it:
 
 > Please merge the PR when you're ready and let me know.
 

--- a/implement/WORKFLOW.md
+++ b/implement/WORKFLOW.md
@@ -65,18 +65,24 @@ For each unchecked issue in `.agent-docs/issues/<branch-name>.md`, in dependency
 
 Run the `code-review` skill.
 
-## Step 7 — Merge
+## Step 7 — Merge and close issues
 
 The PR link was shared at the end of `/code-review`. Prompt the user to merge it:
 
 > Please merge the PR when you're ready and let me know.
 
-Once the user confirms, verify:
+- If the response is not a clear confirmation, press the user again.
+- Once confirmation is given, verify:
 
-```bash
-gh pr view <number> --json state --jq '.state'
-```
+  ```bash
+  gh pr view <number> --json state --jq '.state'
+  ```
 
-Use `gh pr view <number>` with the actual PR number — the `--head` flag is not supported by this version of `gh`.
+  Use `gh pr view <number>` with the actual PR number — the `--head` flag is not supported by this version of `gh`.
 
-If the state is not `MERGED`, tell the user and wait for confirmation again.
+- If the state is not `MERGED`, tell the user and press them again.
+- Once verified as `MERGED`, close all GitHub issues referenced in `.agent-docs/issues/<branch-name>.md`:
+
+  ```bash
+  gh issue close <number> --comment "Closed: merged via PR."
+  ```

--- a/pr-cleanup/SKILL.md
+++ b/pr-cleanup/SKILL.md
@@ -24,7 +24,15 @@ Read `.agent-docs/issues/<branch-name>.md`. Mark all acceptance criteria checkbo
 
 Stage the issues file and commit with the message `"Close <branch-name> issues"`.
 
-### 4. Share PR link
+### 4. Close GitHub issues
+
+For each issue number found in the issues file:
+
+```bash
+gh issue close <number> --comment "Closed: merged via PR."
+```
+
+### 5. Share PR link
 
 ```bash
 gh pr view <number> --json url --jq '.url'

--- a/pr-cleanup/SKILL.md
+++ b/pr-cleanup/SKILL.md
@@ -18,11 +18,11 @@ gh pr list --head <branch> --json number --jq '.[0].number'
 
 ### 2. Update the local issues file
 
-Read `.agent-docs/issues/<branch-name>.md`. Mark all acceptance criteria checkboxes as checked (`- [x]`).
+Read `.agent-docs/issues/<branch-name>.md`. Extract all GitHub issue numbers referenced in the file. Mark all acceptance criteria checkboxes as checked (`- [x]`).
 
 ### 3. Commit and push
 
-Stage the issues file and commit with the message `"Close <branch-name> issues"`, then push the branch.
+Stage the issues file and commit with the message `"Close <actual-branch-name> issues"` (substituting the real branch name from Step 1), then push the branch.
 
 ### 4. Close GitHub issues
 

--- a/pr-cleanup/SKILL.md
+++ b/pr-cleanup/SKILL.md
@@ -22,7 +22,7 @@ Read `.agent-docs/issues/<branch-name>.md`. Mark all acceptance criteria checkbo
 
 ### 3. Commit and push
 
-Stage the issues file and commit with the message `"Close <branch-name> issues"`.
+Stage the issues file and commit with the message `"Close <branch-name> issues"`, then push the branch.
 
 ### 4. Close GitHub issues
 

--- a/pr-cleanup/SKILL.md
+++ b/pr-cleanup/SKILL.md
@@ -18,25 +18,13 @@ gh pr list --head <branch> --json number --jq '.[0].number'
 
 ### 2. Update the local issues file
 
-Read `.agent-docs/issues/<branch-name>.md`. Mark all acceptance criteria checkboxes as checked (`- [x]`) and add a closing note at the top:
-
-```md
-> Merged and closed.
-```
+Read `.agent-docs/issues/<branch-name>.md`. Mark all acceptance criteria checkboxes as checked (`- [x]`).
 
 ### 3. Commit and push
 
-Stage the issues file and commit with the message `"Close <branch-name> issues"`. Do **not** add Copilot as a reviewer after pushing.
+Stage the issues file and commit with the message `"Close <branch-name> issues"`.
 
-### 4. Close GitHub issues
-
-For each issue number found in the issues file:
-
-```bash
-gh issue close <number> --comment "Closed: merged via PR."
-```
-
-### 5. Share PR link
+### 4. Share PR link
 
 ```bash
 gh pr view <number> --json url --jq '.url'

--- a/pr-cleanup/SKILL.md
+++ b/pr-cleanup/SKILL.md
@@ -1,51 +1,45 @@
 ---
 name: pr-cleanup
-description: Post-merge cleanup — close GitHub issues for the current branch and check them off in .agent-docs/issues/<branch-name>.md. Use when a PR has been merged and issues need closing, or when invoked by /implement after the merge confirmation loop.
+description: Pre-merge cleanup — check off acceptance criteria in .agent-docs/issues/<branch-name>.md, commit to the PR branch, close GitHub issues, and share the PR link for merging. Invoked automatically by /code-review after the Copilot review loop.
 ---
 
 # PR Cleanup
 
-Close GitHub issues and update the local issues file after a PR is merged.
+Commit final housekeeping to the PR branch, close GitHub issues, and share the PR link for merging.
 
 ## Process
 
-### 1. Verify the PR is merged
-
-Get the current branch:
+### 1. Get the PR number
 
 ```bash
 git branch --show-current
+gh pr list --head <branch> --json number --jq '.[0].number'
 ```
 
-Confirm the PR is actually merged before proceeding. Direct user or agent confirmation is not required; use the GitHub CLI to check the PR state:
+### 2. Update the local issues file
 
-```bash
-gh pr list --head $(git branch --show-current) --json number --jq '.[0].number'
-gh pr view <number> --json state --jq '.state'
-```
-
-If the state is not `MERGED`, stop and tell the user the PR has not been merged yet.
-
-### 2. Read the local issues file
-
-Read `.agent-docs/issues/<branch-name>.md`. Extract all GitHub issue numbers referenced in the file.
-
-### 3. Close GitHub issues
-
-For each issue number found:
-
-```bash
-gh issue close <number> --comment "Closed: merged via PR."
-```
-
-### 4. Check off items in the local issues file
-
-Update `.agent-docs/issues/<branch-name>.md` — mark all acceptance criteria checkboxes as checked (`- [x]`) and add a closing note at the top of the file:
+Read `.agent-docs/issues/<branch-name>.md`. Mark all acceptance criteria checkboxes as checked (`- [x]`) and add a closing note at the top:
 
 ```md
 > Merged and closed.
 ```
 
-### 5. Report
+### 3. Commit and push
 
-List the closed issue numbers and confirm the local file is updated.
+Stage the issues file and commit with the message `"Close <branch-name> issues"`. Do **not** add Copilot as a reviewer after pushing.
+
+### 4. Close GitHub issues
+
+For each issue number found in the issues file:
+
+```bash
+gh issue close <number> --comment "Closed: merged via PR."
+```
+
+### 5. Share PR link
+
+```bash
+gh pr view <number> --json url --jq '.url'
+```
+
+Share the URL. The PR is ready to merge.

--- a/pr-cleanup/SKILL.md
+++ b/pr-cleanup/SKILL.md
@@ -18,7 +18,11 @@ gh pr list --head <branch> --json number --jq '.[0].number'
 
 ### 2. Update the local issues file
 
-Read `.agent-docs/issues/<branch-name>.md`. Extract all GitHub issue numbers referenced in the file. Mark all acceptance criteria checkboxes as checked (`- [x]`).
+Read `.agent-docs/issues/<branch-name>.md`. Extract all GitHub issue numbers referenced in the file. Mark all acceptance criteria checkboxes as checked (`- [x]`) and add a closing note at the top:
+
+```md
+> Issues closed — PR ready to merge.
+```
 
 ### 3. Commit and push
 

--- a/pr-cleanup/SKILL.md
+++ b/pr-cleanup/SKILL.md
@@ -12,16 +12,18 @@ Commit final housekeeping to the PR branch, close GitHub issues, and share the P
 ### 1. Get the PR number
 
 ```bash
-git branch --show-current
-gh pr list --head <branch> --json number --jq '.[0].number'
+BRANCH=$(git branch --show-current)
+gh pr list --head "$BRANCH" --json number --jq '.[0].number'
 ```
+
+Store the returned number — it is referenced as `<PR-number>` in the steps below.
 
 ### 2. Update the local issues file
 
 Read `.agent-docs/issues/<branch-name>.md`. Extract all GitHub issue numbers referenced in the file. Mark all acceptance criteria checkboxes as checked (`- [x]`) and add a closing note at the top:
 
 ```md
-> Issues closed — PR ready to merge.
+> Work complete — PR ready to merge.
 ```
 
 ### 3. Commit and push
@@ -33,13 +35,13 @@ Stage the issues file and commit with the message `"Close <actual-branch-name> i
 For each issue number found in the issues file:
 
 ```bash
-gh issue close <number> --comment "Closed: merged via PR."
+gh issue close <number> --comment "Closed: implementation complete, see PR for review."
 ```
 
 ### 5. Share PR link
 
 ```bash
-gh pr view <number> --json url --jq '.url'
+gh pr view <PR-number> --json url --jq '.url'
 ```
 
 Share the URL. The PR is ready to merge.

--- a/pr-cleanup/SKILL.md
+++ b/pr-cleanup/SKILL.md
@@ -13,14 +13,14 @@ Commit final housekeeping to the PR branch, close GitHub issues, and share the P
 
 ```bash
 BRANCH=$(git branch --show-current)
-gh pr list --head "$BRANCH" --json number --jq '.[0].number'
+gh pr view --json number --jq '.number'
 ```
 
-Store the returned number — it is referenced as `<PR-number>` in the steps below.
+Store the returned number — it is referenced as `<PR-number>` in the steps below. `gh pr view` resolves the PR for the current branch and fails fast if none exists.
 
 ### 2. Update the local issues file
 
-Read `.agent-docs/issues/<branch-name>.md`. Extract all GitHub issue numbers referenced in the file. Mark all acceptance criteria checkboxes as checked (`- [x]`) and add a closing note at the top:
+Read `.agent-docs/issues/$BRANCH.md`. Extract all GitHub issue numbers referenced in the file. Mark all acceptance criteria checkboxes as checked (`- [x]`) and add a closing note at the top:
 
 ```md
 > Work complete — PR ready to merge.


### PR DESCRIPTION
## Summary

- `pr-cleanup` now runs after Copilot reviews complete (as `code-review` Step 7), before the PR is merged
- `pr-cleanup` commits the issues file, closes GitHub issues, and shares the PR link for merging
- `implement` Step 7 simplified to a merge confirmation loop — cleanup is handled inside `code-review`

## Test plan

- [ ] Run `/implement` on a branch with issues and verify pr-cleanup fires after the Copilot loop, before prompting to merge
- [ ] Confirm issues file is committed and pushed to the PR branch
- [ ] Confirm GitHub issues are closed before merge
- [ ] Confirm PR link is shared and user is prompted to merge
- [ ] Confirm implement Step 7 verifies `MERGED` state after user merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)