### PR TITLE
chore: add clean-review early exit to address-copilot-comments Step 3 poll loop

### DIFF
--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -1,0 +1,98 @@
+---
+name: skills-context
+description: Domain glossary for the Claude Code skills repository — terminology used across skill definitions, workflows, and agent-docs conventions.
+metadata:
+  type: reference
+---
+
+# Claude Code Skills
+
+A repository of self-contained agent skills installed to `~/.claude/skills/`. Each skill defines a named workflow that the Claude Code harness invokes when the user types `/<skill-name>`.
+
+## Language
+
+### Skill System
+
+**Skill**:
+A named, self-contained unit of agent instructions stored as a directory under `~/.claude/skills/<skill-name>/`. Invoked by the harness when the user types `/<skill-name>`.
+_Avoid_: command, tool, plugin, script
+
+**SKILL.md**:
+The required entrypoint file for a skill. Contains the skill's frontmatter (`name`, `description`) and step-by-step instructions. The agent reads this file at invocation.
+_Avoid_: skill file, main file, entrypoint file
+
+**REFERENCE.md**:
+A supplementary file co-located with `SKILL.md`, holding detailed commands, queries, and platform-specific syntax extracted to keep `SKILL.md` concise.
+_Avoid_: detail file, command reference, documentation file
+
+**WORKFLOW.md**:
+A file used by orchestrating skills (e.g. `implement`) to define a multi-step workflow executed inline in the current conversation rather than delegated to a sub-agent.
+_Avoid_: process file, workflow definition
+
+### Workflow Execution
+
+**Step**:
+A numbered phase within a skill's workflow, executed in order unless the skill explicitly branches or terminates early.
+_Avoid_: phase, stage, action
+
+**Loop** (workflow context):
+A defined iteration cycle within a skill's steps, with an explicit termination condition (e.g. "max 10 attempts", "until clean").
+_Avoid_: iteration, cycle, repeat
+
+### PR Review Loop
+
+**Review round**:
+In `address-copilot-comments`, a counter tracking how many times Copilot has been requested to review a PR. Capped at 2; incrementing past the cap skips re-triggering.
+_Avoid_: review iteration, Copilot attempt, pass
+
+**Unresolved thread**:
+A PR review comment thread that has not yet been marked resolved via GitHub's `resolveReviewThread` GraphQL mutation.
+_Avoid_: open comment, pending thread, active comment
+
+**Push back**:
+A decision in the `address-copilot-comments` skill to reject a Copilot comment: reply "Ignored." and resolve the thread without applying a code change.
+_Avoid_: reject, dismiss, decline comment
+
+### Agent Docs
+
+**Agent docs**:
+The `.agent-docs/` directory containing agent-facing documentation for a repository: `agent.md`, `context.md`, `specs/`, `issues/`, and `adr/`.
+_Avoid_: agent documentation, agent directory, .agent-docs folder
+
+**Context** (agent-docs sense):
+The domain glossary file (`context.md`) that defines bounded language for a project. Agents read it to use correct terminology.
+_Avoid_: glossary, dictionary, vocabulary file
+
+**Spec**:
+A PRD-style document written to `.agent-docs/specs/<branch-name>.md` after a grill session, capturing what to build and why before any code is written.
+_Avoid_: PRD, requirements document, design document
+
+**Issue** (agent-docs sense):
+A vertical-slice work item in `.agent-docs/issues/<branch-name>.md`, derived from a spec and mirrored to GitHub Issues. Tracked with a checklist across the BDD loop.
+_Avoid_: task, ticket, story (except in the GitHub Issues sense)
+
+**ADR** (Architecture Decision Record):
+A record in `.agent-docs/adr/` documenting a significant design choice and its rationale. Named with a zero-padded numeric prefix (e.g. `0001-decision-name.md`).
+_Avoid_: decision log, design decision
+
+### Design and Implementation Process
+
+**Grill**:
+A two-axis design session (business angle then engineering angle) that sharpens scope and surfaces constraints before implementation. Produces material for a spec.
+_Avoid_: design session, planning session, interview
+
+**Vertical slice**:
+A unit of work that delivers end-to-end value, used by `create-issues` to break a spec into independent, shippable issues.
+_Avoid_: story, task, feature slice
+
+**BDD loop**:
+The red-green-refactor cycle used in the `behaviour-driven-development` skill: write a failing Given-When-Then scenario, implement to pass it, then refactor.
+_Avoid_: TDD cycle, test loop, test-first loop
+
+**Pre-commit check**:
+Validation run against changed files before a git commit, driven by `.pre-commit-config.yaml` or `.githooks/pre-commit`. Run by the `pre-commit-check` skill after every code change.
+_Avoid_: lint check, pre-commit hook run, validation step
+
+**Branch hygiene**:
+Validation that the current git branch follows naming conventions (correct type prefix, not a trunk branch, name relevant to the work). Run by the `branch-hygiene` skill.
+_Avoid_: branch naming check, branch validation

--- a/.agent-docs/issues/chore/address-copilot-clean-review-exit.md
+++ b/.agent-docs/issues/chore/address-copilot-clean-review-exit.md
@@ -1,0 +1,24 @@
+# Issues: chore/address-copilot-clean-review-exit
+
+## Add clean-review early exit to Step 3 polling loop
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3, 4
+
+### What to build
+
+Update `address-copilot-comments/SKILL.md` and `address-copilot-comments/REFERENCE.md` so the Step 3 polling loop (and the Step 7 re-poll) can detect when Copilot has reviewed clean and exit to Step 8 immediately, rather than exhausting all 10 attempts.
+
+Before the poll loop begins, capture the latest Copilot review ID as a baseline. Within each iteration, after the existing thread-count check returns 0, compare the current latest Copilot review ID against the baseline. If a new review has been submitted (IDs differ), Copilot reviewed clean — skip to Step 8. If no new review, continue polling as today.
+
+### Acceptance criteria
+
+- [x] The loop diagram in `SKILL.md` shows the new clean-review (new review + 0 threads) path exiting to Step 8.
+- [x] Step 3 prose in `SKILL.md` describes recording a baseline review ID before polling and the early Step 8 exit condition.
+- [x] `REFERENCE.md` Step 3 opens with a baseline capture command (`gh api .../reviews`) before the poll loop.
+- [x] The 0-thread branch in `REFERENCE.md` includes the reviews ID comparison and an explicit "go to Step 8" instruction.
+- [x] The thread count > 0 path exits to Step 4 unchanged.
+- [x] Step 7's "poll as in Step 3" delegation is confirmed to inherit the new behaviour without a separate change to Step 7.
+
+---

--- a/.agent-docs/issues/chore/address-copilot-clean-review-exit.md
+++ b/.agent-docs/issues/chore/address-copilot-clean-review-exit.md
@@ -1,5 +1,7 @@
 # Issues: chore/address-copilot-clean-review-exit
 
+> Work complete — PR ready to merge.
+
 ## Add clean-review early exit to Step 3 polling loop
 
 **Blocked by**: None

--- a/.agent-docs/specs/chore/address-copilot-clean-review-exit.md
+++ b/.agent-docs/specs/chore/address-copilot-clean-review-exit.md
@@ -1,0 +1,65 @@
+# address-copilot-comments: Early exit for clean Copilot review
+
+## Problem Statement
+
+When Copilot reviews a PR and finds nothing to comment on (a "clean" review), the `address-copilot-comments` skill's Step 3 polling loop has no way to detect this. It polls for unresolved threads every 60 seconds for up to 10 attempts, finds zero threads each time, and only exits after the full 10-minute wait. The skill wastes time and gives the user no signal that Copilot has already finished reviewing.
+
+## Solution
+
+Before the polling loop begins, record the latest Copilot review ID as a baseline. Within each poll iteration, after detecting zero unresolved threads, check whether a new Copilot review has been submitted (latest review ID differs from baseline). If yes, Copilot reviewed clean — exit to Step 8 immediately rather than continuing to poll. This applies to both the initial Step 3 poll and the Step 7 re-poll, which delegates to the same logic.
+
+## User Stories
+
+1. As an engineer running `address-copilot-comments` after a PR push, I want the skill to detect when Copilot has reviewed clean, so that I am not blocked waiting 10 minutes for a result that is already available.
+2. As an engineer iterating on a PR, I want the same early-exit behaviour to apply after re-triggering Copilot in Step 6, so that a second clean review also exits promptly.
+3. As an engineer whose PR has real Copilot comments, I want the existing loop behaviour (exit to Step 4 when threads > 0) to remain unchanged, so that fixes are not skipped.
+4. As an engineer whose PR is reviewed by Copilot before the baseline is captured, I want the skill to fall through safely to the existing 10-attempt exhaustion path and Step 8, so that correctness is maintained even in the fast-review edge case.
+
+## Implementation Decisions
+
+- **Baseline capture**: at the start of each polling window (Step 3 entry and Step 7 re-poll entry), run `GET /repos/{owner}/{repo}/pulls/{number}/reviews`, filter to Copilot-authored reviews, and record the ID of the last one. An empty result means no Copilot review exists yet; any review that subsequently appears is considered new.
+- **Per-iteration sequence**: thread count check runs first (unchanged). If thread count > 0, exit to Step 4 as today. If thread count = 0, run the reviews check: if the latest Copilot review ID differs from the baseline, exit to Step 8 (clean review). If the ID matches or is still empty, continue polling.
+- **Scope**: applies to both Step 3 and Step 7. Step 7 already delegates to "poll as in Step 3", so the same baseline-capture-then-poll pattern is followed on re-entry.
+- **No change to termination conditions**: the 10-attempt exhaustion + final check + Step 8 fallthrough is preserved for cases where no new review arrives within the polling window.
+- **Files changed**: `address-copilot-comments/SKILL.md` (loop diagram and Step 3 prose) and `address-copilot-comments/REFERENCE.md` (baseline capture command block and 0-thread branch reviews check).
+
+### Baseline capture command
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty'
+```
+
+Store the result as `BASELINE_REVIEW_ID`. Empty means no Copilot review yet.
+
+### Per-iteration 0-thread branch (new logic)
+
+```bash
+CURRENT_REVIEW_ID=$(gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
+
+if [ "$CURRENT_REVIEW_ID" != "$BASELINE_REVIEW_ID" ] && [ -n "$CURRENT_REVIEW_ID" ]; then
+  # Copilot reviewed clean — go to Step 8
+fi
+```
+
+## Testing Decisions
+
+Skills are Markdown instruction files with no executable test harness. Correctness is verified by human review of the updated files against the acceptance criteria:
+
+1. The loop diagram in `SKILL.md` shows the new clean-review exit path from Step 3.
+2. `REFERENCE.md` Step 3 opens with the baseline capture command before the poll loop.
+3. The existing GraphQL thread-count query runs first in each iteration.
+4. The 0-thread branch in `REFERENCE.md` includes the reviews ID comparison and the Step 8 exit instruction.
+5. Step 7's description ("poll as in Step 3") is confirmed to inherit the new behaviour without a separate change.
+
+## Out of Scope
+
+- Changes to Step 4, Step 5, Step 6, or Step 8 logic.
+- Handling network errors or API failures in the reviews check — the skill already tolerates poll failures by counting them as non-matches and continuing.
+- Reducing the 10-attempt maximum or the 60-second interval.
+- Any changes to skills other than `address-copilot-comments`.
+
+## Further Notes
+
+The reviews check is intentionally placed in the 0-thread branch (Option B from the design session) to avoid an extra API call on the happy path where threads are already present. The clean-review case is the only ambiguous one: thread count = 0 could mean "Copilot hasn't reviewed yet" or "Copilot reviewed and found nothing" — the reviews endpoint is what disambiguates it.

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -47,7 +47,15 @@ query {
 
 If count > 0 — exit the poll loop and continue to Step 4.
 
-**Step B — Reviews check (only when thread count = 0).** Re-run the baseline capture command above, assigning the result to `CURRENT_REVIEW_ID` instead of `BASELINE_REVIEW_ID`. Then:
+**Step B — Reviews check (only when thread count = 0).** Check whether the latest Copilot review ID has changed since the baseline was captured:
+
+```bash
+# Same query as baseline capture above — assigns to CURRENT_REVIEW_ID
+CURRENT_REVIEW_ID=$(gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
+```
+
+Then:
 
 If `CURRENT_REVIEW_ID` is non-empty and differs from `BASELINE_REVIEW_ID` — Copilot has submitted a new review with no actionable threads. **Go to Step 8 immediately.**
 

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -47,12 +47,7 @@ query {
 
 If count > 0 — exit the poll loop and continue to Step 4.
 
-**Step B — Reviews check (only when thread count = 0).** Check whether the latest Copilot review ID has changed since the baseline was captured:
-
-```bash
-CURRENT_REVIEW_ID=$(gh api repos/{owner}/{repo}/pulls/{number}/reviews \
-  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
-```
+**Step B — Reviews check (only when thread count = 0).** Re-run the baseline capture command above, assigning the result to `CURRENT_REVIEW_ID` instead of `BASELINE_REVIEW_ID`. Then:
 
 If `CURRENT_REVIEW_ID` is non-empty and differs from `BASELINE_REVIEW_ID` — Copilot has submitted a new review with no actionable threads. **Go to Step 8 immediately.**
 

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -12,7 +12,20 @@ Get `{owner}/{repo}` from:
 gh repo view --json nameWithOwner --jq '.nameWithOwner'
 ```
 
-Run every 60 seconds until the count is greater than zero. Use GraphQL — the REST `pulls/{number}/comments` endpoint misses threads posted as part of a review submission:
+### Capture baseline Copilot review ID (before the poll loop)
+
+Run once before polling begins. Records the latest Copilot review ID so the loop can detect when a new review is submitted.
+
+```bash
+BASELINE_REVIEW_ID=$(gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
+```
+
+Empty result means no Copilot review exists yet — any review that appears during polling is considered new.
+
+### Poll loop (every 60 seconds, max 10 attempts)
+
+**Step A — Thread count check.** Use GraphQL — the REST `pulls/{number}/comments` endpoint misses threads posted as part of a review submission:
 
 ```bash
 gh api graphql -f query='
@@ -32,7 +45,20 @@ query {
 }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | test("copilot"; "i"))] | length'
 ```
 
-After 10 failed attempts (count still 0), perform one final direct check with the same query. If the final check also returns 0, Copilot has not reviewed or has nothing actionable — continue to Step 8.
+If count > 0 — exit the poll loop and continue to Step 4.
+
+**Step B — Reviews check (only when thread count = 0).** Check whether the latest Copilot review ID has changed since the baseline was captured:
+
+```bash
+CURRENT_REVIEW_ID=$(gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
+```
+
+If `CURRENT_REVIEW_ID` is non-empty and differs from `BASELINE_REVIEW_ID` — Copilot has submitted a new review with no actionable threads. **Go to Step 8 immediately.**
+
+If `CURRENT_REVIEW_ID` equals `BASELINE_REVIEW_ID` (or is still empty) — no new review yet. Wait 60 seconds and repeat.
+
+After 10 failed attempts (thread count still 0 and no new review detected), perform one final pass of Steps A and B with the same queries. If the final pass also returns 0 threads and no new review, Copilot has not yet reviewed or has nothing actionable — continue to Step 8.
 
 ---
 
@@ -171,6 +197,6 @@ The loop is complete when **any** of these conditions is met:
 
 1. **All push-backs in a round** — no code changes were made. Threads are already resolved after Step 4c. Skip Steps 5–7; do not re-trigger Copilot. PR is ready to merge.
 2. **Max reviews reached** — `review_round >= 2` at Step 6. Do not re-trigger. PR is ready to merge.
-3. **No new unresolved threads** after re-triggering — poll in Step 7 returns zero unresolved Copilot threads.
+3. **Clean review or poll exhausted** — the Step 3 poll (or Step 7 re-poll) ends with zero unresolved threads. Either a new Copilot review was detected with no comments (exits immediately to Step 8), or 10 attempts elapsed with no new review (falls through to Step 8).
 
 In all cases the PR is considered clean and ready to merge.

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -17,7 +17,7 @@ gh repo view --json nameWithOwner --jq '.nameWithOwner'
 Run once before polling begins. Records the latest Copilot review ID so the loop can detect when a new review is submitted.
 
 ```bash
-BASELINE_REVIEW_ID=$(gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+BASELINE_REVIEW_ID=$(gh api "repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100" \
   --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
 ```
 
@@ -51,7 +51,7 @@ If count > 0 — exit the poll loop and continue to Step 4.
 
 ```bash
 # Same query as baseline capture above — assigns to CURRENT_REVIEW_ID
-CURRENT_REVIEW_ID=$(gh api repos/{owner}/{repo}/pulls/{number}/reviews \
+CURRENT_REVIEW_ID=$(gh api "repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100" \
   --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
 ```
 

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -66,7 +66,7 @@ Before polling, capture the latest Copilot review ID as a baseline (empty if no 
 Poll every 60 seconds, max 10 attempts:
 
 1. Run the thread count check. If > 0, exit to Step 4.
-2. If 0, check whether the latest Copilot review ID differs from the baseline. If yes, Copilot reviewed clean — go to Step 8 immediately.
+2. If 0, check whether the latest Copilot review ID is non-empty and differs from the baseline. If yes, Copilot reviewed clean — go to Step 8 immediately.
 3. If no new review, wait and repeat.
 
 After 10 attempts with no new clean review, perform one final check following the same branching: threads > 0 → exit to Step 4; otherwise go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for the queries.

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -15,8 +15,10 @@ Runs a loop: fetch Copilot comments → fix or push back → commit → push →
 Step 0  gh available?
 Step 1  PR exists? ──No──► Step 2: create PR (review_round = 1)
         PR exists? ──Yes──► review_round = 1
-Step 3  Poll for unresolved Copilot review threads (60s)
-        Poll exhausted (0 threads after 10 attempts + fallback)? ──► Step 8
+Step 3  Record baseline Copilot review ID; poll every 60s:
+        thread count > 0? ─────────────────────────────────────────► Step 4
+        thread count = 0 + new Copilot review (IDs differ)? ───────► Step 8 (reviewed clean)
+        Poll exhausted (no new review, 0 threads, 10 attempts)? ───► Step 8
 Step 4  For each unresolved thread: decide fix or push-back; apply code changes
 Step 4b Run code-review (Steps 1–5 only; skip code-review Step 6) to validate changes
 Step 4c Reply to each thread ("Fixed." / "Ignored.") → resolve thread immediately
@@ -57,7 +59,7 @@ Note the PR number. Set `review_round = 1`. The first Copilot review triggers au
 
 ## Step 3 — Poll for Copilot review threads
 
-Poll every 60 seconds (max 10 attempts) until unresolved Copilot thread count > 0; one final check if still 0; if still empty after that, go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for the GraphQL query.
+Before polling, capture the latest Copilot review ID as a baseline (empty if no review exists yet). Poll every 60 seconds (max 10 attempts): run the thread count check first; if > 0, exit to Step 4. If 0, check whether the latest Copilot review ID differs from the baseline — if yes, Copilot reviewed clean, go to Step 8 immediately. One final check after 10 attempts; if still no new clean review, go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for both queries.
 
 ## Step 4 — Decide and apply changes
 

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -26,7 +26,8 @@ Step 4c Reply to each thread ("Fixed." / "Ignored.") → resolve thread immediat
 Step 5  Execute pre-commit-checks or .git/hooks/pre-commit (if any) → commit → push
 Step 6  review_round < 2? ──Yes──► review_round++; re-trigger Copilot → Step 7
                           ──No ──► Step 8 (max 2 reviews; do not re-trigger)
-Step 7  New unresolved Copilot threads? ──Yes──► Step 4 | No ──► Step 8
+Step 7  Re-capture baseline; poll as in Step 3:
+        threads? ──► Step 4 | clean or exhausted? ──► Step 8
 Step 8  Report PR link — PR is ready to merge
 ```
 
@@ -59,7 +60,15 @@ Note the PR number. Set `review_round = 1`. The first Copilot review triggers au
 
 ## Step 3 — Poll for Copilot review threads
 
-Before polling, capture the latest Copilot review ID as a baseline (empty if no review exists yet). Poll every 60 seconds (max 10 attempts): run the thread count check first; if > 0, exit to Step 4. If 0, check whether the latest Copilot review ID differs from the baseline — if yes, Copilot reviewed clean, go to Step 8 immediately. One final check after 10 attempts; if still no new clean review, go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for the queries.
+Before polling, capture the latest Copilot review ID as a baseline (empty if no review exists yet).
+
+Poll every 60 seconds, max 10 attempts:
+
+1. Run the thread count check. If > 0, exit to Step 4.
+2. If 0, check whether the latest Copilot review ID differs from the baseline. If yes, Copilot reviewed clean — go to Step 8 immediately.
+3. If no new review, wait and repeat.
+
+After 10 attempts with no new clean review, perform one final check then go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for the queries.
 
 ## Step 4 — Decide and apply changes
 

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -59,7 +59,7 @@ Note the PR number. Set `review_round = 1`. The first Copilot review triggers au
 
 ## Step 3 — Poll for Copilot review threads
 
-Before polling, capture the latest Copilot review ID as a baseline (empty if no review exists yet). Poll every 60 seconds (max 10 attempts): run the thread count check first; if > 0, exit to Step 4. If 0, check whether the latest Copilot review ID differs from the baseline — if yes, Copilot reviewed clean, go to Step 8 immediately. One final check after 10 attempts; if still no new clean review, go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for both queries.
+Before polling, capture the latest Copilot review ID as a baseline (empty if no review exists yet). Poll every 60 seconds (max 10 attempts): run the thread count check first; if > 0, exit to Step 4. If 0, check whether the latest Copilot review ID differs from the baseline — if yes, Copilot reviewed clean, go to Step 8 immediately. One final check after 10 attempts; if still no new clean review, go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for the queries.
 
 ## Step 4 — Decide and apply changes
 
@@ -83,7 +83,7 @@ If `review_round >= 2`, skip to Step 8. Otherwise increment to 2 and re-trigger 
 
 ## Step 7 — Check for new threads
 
-Wait 60 seconds, poll as in Step 3. New unresolved threads → return to Step 4. None → continue to Step 8.
+Re-capture the baseline Copilot review ID, then poll as in Step 3. New unresolved threads → return to Step 4. None (or clean review detected) → continue to Step 8.
 
 ## Step 8 — Report completion
 

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -18,7 +18,8 @@ Step 1  PR exists? ──No──► Step 2: create PR (review_round = 1)
 Step 3  Record baseline Copilot review ID; poll every 60s:
         thread count > 0? ─────────────────────────────────────────► Step 4
         thread count = 0 + new Copilot review (IDs differ)? ───────► Step 8 (reviewed clean)
-        Poll exhausted (no new review, 0 threads, 10 attempts)? ───► Step 8
+        Poll exhausted? one final pass: threads > 0? ─────────────► Step 4
+                        final pass: 0 threads, no new review? ──► Step 8
 Step 4  For each unresolved thread: decide fix or push-back; apply code changes
 Step 4b Run code-review (Steps 1–5 only; skip code-review Step 6) to validate changes
 Step 4c Reply to each thread ("Fixed." / "Ignored.") → resolve thread immediately
@@ -68,7 +69,7 @@ Poll every 60 seconds, max 10 attempts:
 2. If 0, check whether the latest Copilot review ID differs from the baseline. If yes, Copilot reviewed clean — go to Step 8 immediately.
 3. If no new review, wait and repeat.
 
-After 10 attempts with no new clean review, perform one final check then go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for the queries.
+After 10 attempts with no new clean review, perform one final check following the same branching: threads > 0 → exit to Step 4; otherwise go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for the queries.
 
 ## Step 4 — Decide and apply changes
 


### PR DESCRIPTION
## Summary

- Before each polling window (Step 3 and Step 7 re-poll), capture the latest Copilot review ID as a baseline.
- Per iteration: run thread count check first; if 0, compare current review ID against baseline — if a new review exists with 0 threads, Copilot reviewed clean → skip to Step 8 immediately.
- Fixes the 10-minute unnecessary wait when Copilot reviews a PR and finds nothing to comment on.
- Step 7 updated to re-capture the baseline before polling, preventing a stale-baseline false early exit after re-triggering.

Closes #28

## Test plan

- [ ] `SKILL.md` loop diagram shows all three Step 3 exit paths (threads > 0 → Step 4, new review + 0 threads → Step 8, exhausted → Step 8).
- [ ] `SKILL.md` Step 3 prose lists the per-iteration numbered sequence.
- [ ] `SKILL.md` Step 7 says "Re-capture the baseline Copilot review ID, then poll as in Step 3."
- [ ] `REFERENCE.md` Step 3 opens with the baseline capture command before the poll loop.
- [ ] `REFERENCE.md` Step B re-runs the baseline command (no duplication) and instructs "Go to Step 8 immediately" on new clean review.
- [ ] `REFERENCE.md` loop termination condition 3 covers both clean-review and poll-exhausted exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)