### PR TITLE
bugfix: add pull_number to reply endpoint path in REFERENCE.md

### DIFF
--- a/.agent-docs/issues/bugfix/reply-endpoint-pull-number.md
+++ b/.agent-docs/issues/bugfix/reply-endpoint-pull-number.md
@@ -10,12 +10,12 @@
 
 ### What to build
 
-Replace the broken path in both "Reply: fixed" and "Reply: push back" command blocks in `address-copilot-comments/REFERENCE.md`. The path `pulls/comments/{comment_id}/replies` returns 404; the correct path is `pulls/{pull_number}/comments/{comment_id}/replies`.
+Replace the broken path in both "Reply: fixed" and "Reply: push back" command blocks in `address-copilot-comments/REFERENCE.md`. The path `pulls/comments/{comment_id}/replies` returns 404; the correct path is `pulls/{number}/comments/{comment_id}/replies`.
 
 ### Acceptance criteria
 
-- [ ] "Reply: fixed" block uses `pulls/{pull_number}/comments/{comment_id}/replies`
-- [ ] "Reply: push back" block uses `pulls/{pull_number}/comments/{comment_id}/replies`
+- [ ] "Reply: fixed" block uses `pulls/{number}/comments/{comment_id}/replies`
+- [ ] "Reply: push back" block uses `pulls/{number}/comments/{comment_id}/replies`
 - [ ] No other lines in `REFERENCE.md` are changed
 
 ---

--- a/.agent-docs/issues/bugfix/reply-endpoint-pull-number.md
+++ b/.agent-docs/issues/bugfix/reply-endpoint-pull-number.md
@@ -1,0 +1,21 @@
+# Issues: bugfix/reply-endpoint-pull-number
+
+## Fix reply endpoint to include pull_number
+
+**GitHub**: #32
+
+**Blocked by**: None
+
+**User stories**: 1
+
+### What to build
+
+Replace the broken path in both "Reply: fixed" and "Reply: push back" command blocks in `address-copilot-comments/REFERENCE.md`. The path `pulls/comments/{comment_id}/replies` returns 404; the correct path is `pulls/{pull_number}/comments/{comment_id}/replies`.
+
+### Acceptance criteria
+
+- [ ] "Reply: fixed" block uses `pulls/{pull_number}/comments/{comment_id}/replies`
+- [ ] "Reply: push back" block uses `pulls/{pull_number}/comments/{comment_id}/replies`
+- [ ] No other lines in `REFERENCE.md` are changed
+
+---

--- a/.agent-docs/issues/bugfix/reply-endpoint-pull-number.md
+++ b/.agent-docs/issues/bugfix/reply-endpoint-pull-number.md
@@ -1,5 +1,7 @@
 # Issues: bugfix/reply-endpoint-pull-number
 
+> Work complete — PR ready to merge.
+
 ## Fix reply endpoint to include pull_number
 
 **GitHub**: #32
@@ -14,8 +16,8 @@ Replace the broken path in both "Reply: fixed" and "Reply: push back" command bl
 
 ### Acceptance criteria
 
-- [ ] "Reply: fixed" block uses `pulls/{number}/comments/{comment_id}/replies`
-- [ ] "Reply: push back" block uses `pulls/{number}/comments/{comment_id}/replies`
-- [ ] No other lines in `REFERENCE.md` are changed
+- [x] "Reply: fixed" block uses `pulls/{number}/comments/{comment_id}/replies`
+- [x] "Reply: push back" block uses `pulls/{number}/comments/{comment_id}/replies`
+- [x] No other lines in `REFERENCE.md` are changed
 
 ---

--- a/.agent-docs/specs/bugfix/reply-endpoint-pull-number.md
+++ b/.agent-docs/specs/bugfix/reply-endpoint-pull-number.md
@@ -11,14 +11,14 @@ gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies
 The working path requires the PR number:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies
+gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies
 ```
 
 This causes every reply attempt in the `address-copilot-comments` loop to fail silently or with a 404 error, blocking the agent from acknowledging Copilot comments.
 
 ## Solution
 
-Replace the broken path in both "Reply: fixed" and "Reply: push back" command blocks with the correct path that includes `{pull_number}`.
+Replace the broken path in both "Reply: fixed" and "Reply: push back" command blocks with the correct path that includes `{number}`.
 
 ## User Stories
 
@@ -27,7 +27,7 @@ Replace the broken path in both "Reply: fixed" and "Reply: push back" command bl
 ## Implementation Decisions
 
 - Edit `address-copilot-comments/REFERENCE.md` only.
-- Change `pulls/comments/{comment_id}/replies` to `pulls/{pull_number}/comments/{comment_id}/replies` in both the "Reply: fixed" and "Reply: push back" blocks.
+- Change `pulls/comments/{comment_id}/replies` to `pulls/{number}/comments/{comment_id}/replies` in both the "Reply: fixed" and "Reply: push back" blocks.
 - No other lines change.
 
 ## Testing Decisions

--- a/.agent-docs/specs/bugfix/reply-endpoint-pull-number.md
+++ b/.agent-docs/specs/bugfix/reply-endpoint-pull-number.md
@@ -1,0 +1,41 @@
+# Fix Reply Endpoint Pull Number
+
+## Problem Statement
+
+The reply command blocks in `address-copilot-comments/REFERENCE.md` use a GitHub API path that returns 404:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies
+```
+
+The working path requires the PR number:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies
+```
+
+This causes every reply attempt in the `address-copilot-comments` loop to fail silently or with a 404 error, blocking the agent from acknowledging Copilot comments.
+
+## Solution
+
+Replace the broken path in both "Reply: fixed" and "Reply: push back" command blocks with the correct path that includes `{pull_number}`.
+
+## User Stories
+
+1. As an agent running `address-copilot-comments`, I want the reply endpoint to work so that I can post "Fixed." and "Ignored." replies without getting a 404.
+
+## Implementation Decisions
+
+- Edit `address-copilot-comments/REFERENCE.md` only.
+- Change `pulls/comments/{comment_id}/replies` to `pulls/{pull_number}/comments/{comment_id}/replies` in both the "Reply: fixed" and "Reply: push back" blocks.
+- No other lines change.
+
+## Testing Decisions
+
+- Verification is a read-through: both blocks must use the corrected path.
+- No automated tests apply.
+
+## Out of Scope
+
+- Changes to `SKILL.md`.
+- Any other section of `REFERENCE.md`.

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -102,14 +102,14 @@ The query returns two IDs per thread — use the right one for each operation:
 ### Reply: fixed
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies \
+gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies \
   -X POST -f body="Fixed. <one-line explanation>"
 ```
 
 ### Reply: push back
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies \
+gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies \
   -X POST -f body="Ignored. <reason>"
 ```
 

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -102,14 +102,14 @@ The query returns two IDs per thread — use the right one for each operation:
 ### Reply: fixed
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies \
+gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
   -X POST -f body="Fixed. <one-line explanation>"
 ```
 
 ### Reply: push back
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/{pull_number}/comments/{comment_id}/replies \
+gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies \
   -X POST -f body="Ignored. <reason>"
 ```
 


### PR DESCRIPTION
## Summary

- Fixes the `gh api` reply endpoint in both "Reply: fixed" and "Reply: push back" command blocks in `address-copilot-comments/REFERENCE.md`.
- The path `pulls/comments/{comment_id}/replies` returns 404 in practice; the correct path is `pulls/{pull_number}/comments/{comment_id}/replies`.

## Test plan

- [ ] "Reply: fixed" block uses `pulls/{pull_number}/comments/{comment_id}/replies`
- [ ] "Reply: push back" block uses `pulls/{pull_number}/comments/{comment_id}/replies`
- [ ] No other lines in `REFERENCE.md` changed

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)