### PR TITLE
Fix --add-reviewer PowerShell quoting in address-copilot-comments Step 6

### DIFF
--- a/.agent-docs/issues/bugfix/fix-add-reviewer-powershell-quoting.md
+++ b/.agent-docs/issues/bugfix/fix-add-reviewer-powershell-quoting.md
@@ -1,0 +1,26 @@
+# Issues: bugfix/fix-add-reviewer-powershell-quoting
+
+## Fix `--add-reviewer` PowerShell quoting in REFERENCE.md Step 6
+
+**GitHub**: #34
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3
+
+### What to build
+
+Update Step 6 of `address-copilot-comments/REFERENCE.md` with three changes:
+
+- Quote `@copilot` as `'@copilot'` in the Option A code block
+- Add a blockquote note below Option A explaining that single-quoting is required in PowerShell because bare `@copilot` is parsed as a splat operator and silently drops the argument
+- Change the Option B heading from `(if Option A fails)` to `(fallback if gh pr edit is unavailable)`
+
+### Acceptance criteria
+
+- [ ] Option A code block reads `gh pr edit {number} --add-reviewer '@copilot'`
+- [ ] A note below Option A explains the PowerShell splat-operator issue
+- [ ] Option B heading reads `(fallback if gh pr edit is unavailable)`
+- [ ] No other lines in REFERENCE.md are modified
+
+---

--- a/.agent-docs/issues/bugfix/fix-add-reviewer-powershell-quoting.md
+++ b/.agent-docs/issues/bugfix/fix-add-reviewer-powershell-quoting.md
@@ -1,5 +1,7 @@
 # Issues: bugfix/fix-add-reviewer-powershell-quoting
 
+> Work complete — PR ready to merge.
+
 ## Fix `--add-reviewer` PowerShell quoting in REFERENCE.md Step 6
 
 **GitHub**: #34
@@ -18,9 +20,9 @@ Update Step 6 of `address-copilot-comments/REFERENCE.md` with three changes:
 
 ### Acceptance criteria
 
-- [ ] Option A code block reads `gh pr edit {number} --add-reviewer '@copilot'`
-- [ ] A note below Option A explains the PowerShell splat-operator issue
-- [ ] Option B heading reads `(fallback if gh pr edit is unavailable)`
-- [ ] No other lines in REFERENCE.md are modified
+- [x] Option A code block reads `gh pr edit {number} --add-reviewer '@copilot'`
+- [x] A note below Option A explains the PowerShell splat-operator issue
+- [x] Option B heading reads `(fallback if gh pr edit is unavailable)`
+- [x] No other lines in REFERENCE.md are modified
 
 ---

--- a/.agent-docs/specs/bugfix/fix-add-reviewer-powershell-quoting.md
+++ b/.agent-docs/specs/bugfix/fix-add-reviewer-powershell-quoting.md
@@ -1,0 +1,59 @@
+# Fix --add-reviewer PowerShell quoting in address-copilot-comments
+
+## Problem Statement
+
+When a user runs the Step 6 Option A command from `address-copilot-comments/REFERENCE.md` in
+PowerShell, the command silently drops the `--add-reviewer` argument because PowerShell parses
+bare `@copilot` as a splat operator. This causes `gh` to error with
+`flag needs an argument: --add-reviewer`. Without the `@` prefix, `copilot` fails with a
+GraphQL login resolution error. Neither form works in PowerShell as currently documented.
+
+Additionally, Option B is labelled "if Option A fails", which implies it is a generic fallback
+for any failure mode. In practice Option B is needed only when `gh pr edit` itself is
+unavailable due to plan or org restrictions — not as a workaround for the quoting bug.
+
+## Solution
+
+Quote `@copilot` in single quotes in the Option A command block so it works in both PowerShell
+and Bash. Add a brief note explaining the PowerShell splat-operator behaviour. Relabel Option B
+to make clear it is a fallback for when `gh pr edit` is unavailable, not a shell-specific
+workaround.
+
+## User Stories
+
+1. As an agent running on PowerShell, I want the Step 6 Option A command to use
+   `'@copilot'` so that `gh pr edit` does not error with `flag needs an argument`.
+2. As a developer reading REFERENCE.md, I want the Option B heading to explain when to
+   use it, so that I do not reach for GraphQL when the quoted Option A would have worked.
+3. As a Bash user, I want the single-quoted form to remain valid in my shell, so that the
+   fix does not break existing workflows.
+
+## Implementation Decisions
+
+- Edit `address-copilot-comments/REFERENCE.md`, Step 6 section only.
+- Change `@copilot` to `'@copilot'` in the Option A code block.
+- Add a blockquote note immediately below the Option A code block explaining that
+  single-quoting is required in PowerShell because bare `@copilot` is parsed as a splat
+  operator and silently drops the argument.
+- Change the Option B heading from `(if Option A fails)` to
+  `(fallback if gh pr edit is unavailable)`.
+- No other files or steps are modified.
+
+## Testing Decisions
+
+- This is a documentation-only change. Correctness is verified by reading the updated file
+  and confirming the three edits are applied accurately.
+- No automated tests exist or are warranted for REFERENCE.md content.
+
+## Out of Scope
+
+- Changes to any other step in REFERENCE.md.
+- Changes to SKILL.md or any other skill file.
+- Fixing any other shell-compatibility issues.
+
+## Further Notes
+
+Single quotes are valid in both PowerShell (literal string, no interpolation) and Bash, so
+`'@copilot'` is the correct cross-shell form. The GraphQL mutation in Option B works on any
+shell; the heading change clarifies its trigger condition (plan/org availability) rather than
+implying a shell restriction.

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -156,10 +156,12 @@ mutation {
 ### Option A — `gh pr edit` (most plans)
 
 ```bash
-gh pr edit {number} --add-reviewer @copilot
+gh pr edit {number} --add-reviewer '@copilot'
 ```
 
-### Option B — GraphQL `requestReviews` mutation (if Option A fails)
+> In PowerShell, bare `@copilot` is parsed as a splat operator and silently drops the argument, causing `gh` to error with `flag needs an argument: --add-reviewer`. Single quotes are required.
+
+### Option B — GraphQL `requestReviews` mutation (fallback if `gh pr edit` is unavailable)
 
 ```bash
 gh api graphql -f query='

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -159,7 +159,7 @@ mutation {
 gh pr edit {number} --add-reviewer '@copilot'
 ```
 
-> In PowerShell, bare `@copilot` is parsed as a splat operator and consumed before arguments are passed to `gh`, so `gh` never receives the reviewer value and errors with `flag needs an argument: --add-reviewer`. Single quotes prevent this.
+> In PowerShell, bare `@copilot` is parsed as a splat operator and consumed before arguments are passed to `gh`, so `gh` never receives the reviewer value and errors with `flag needs an argument: --add-reviewer`. Single-quote `'@copilot'` to prevent this.
 
 ### Option B — GraphQL `requestReviews` mutation (fallback if `gh pr edit` is unavailable)
 

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -159,7 +159,7 @@ mutation {
 gh pr edit {number} --add-reviewer '@copilot'
 ```
 
-> In PowerShell, bare `@copilot` is parsed as a splat operator and silently drops the argument, causing `gh` to error with `flag needs an argument: --add-reviewer`. Single quotes are required.
+> In PowerShell, bare `@copilot` is parsed as a splat operator and consumed before arguments are passed to `gh`, so `gh` never receives the reviewer value and errors with `flag needs an argument: --add-reviewer`. Single quotes prevent this.
 
 ### Option B — GraphQL `requestReviews` mutation (fallback if `gh pr edit` is unavailable)
 


### PR DESCRIPTION
## Summary

- Quote `'@copilot'` in single quotes in the Step 6 Option A command so it works in PowerShell (bare `@copilot` is parsed as a splat operator and drops the argument)
- Add a blockquote note below Option A explaining the PowerShell splat-operator behaviour
- Relabel Option B heading from `(if Option A fails)` to `(fallback if gh pr edit is unavailable)` to clarify it is triggered by plan/org availability, not shell type

## Test plan

- [ ] Read `address-copilot-comments/REFERENCE.md` Step 6 — confirm Option A command uses `'@copilot'`
- [ ] Confirm blockquote note below Option A explains the PowerShell splat-operator issue
- [ ] Confirm Option B heading reads `(fallback if gh pr edit is unavailable)`
- [ ] Confirm no other lines in REFERENCE.md were modified

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)