### PR TITLE
Fix address-copilot-comments: detect and act on Copilot's suppressed comments

### DIFF
--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -56,6 +56,10 @@ _Avoid_: open comment, pending thread, active comment
 A decision in the `address-copilot-comments` skill to reject a Copilot comment: reply "Ignored." and resolve the thread without applying a code change.
 _Avoid_: reject, dismiss, decline comment
 
+**Suppressed comment**:
+A Copilot finding folded into the review body's collapsible `### Suppressed comments (N)` markdown block instead of posted as a real Unresolved thread. Has no `databaseId`/thread ID, so it is invisible to thread-count checks and can't be replied-to or resolved individually — `address-copilot-comments` acknowledges these instead with a single PR-level comment.
+_Avoid_: hidden comment, collapsed comment, filtered finding
+
 ### Agent Docs
 
 **Agent docs**:

--- a/.agent-docs/issues/bugfix/address-copilot-suppressed-comments.md
+++ b/.agent-docs/issues/bugfix/address-copilot-suppressed-comments.md
@@ -1,5 +1,7 @@
 # Issues: bugfix/address-copilot-suppressed-comments
 
+> Work complete — PR ready to merge.
+
 ## Detect suppressed comments during polling
 
 **GitHub issue**: #39
@@ -14,11 +16,11 @@ Add a second check to the Step 3/7 poll (and its final pass after poll exhaustio
 
 ### Acceptance criteria
 
-- [ ] Step 3 and Step 7 poll logic (SKILL.md) check both thread count and suppressed-comment count before considering the PR reviewed clean
-- [ ] REFERENCE.md documents the suppressed-comment count extraction (Step A2) with a runnable command, alongside the existing Step A/B detail
-- [ ] The "Loop at a glance" diagram in SKILL.md reflects the new branch
-- [ ] Dry-run: piping the real sample review body (from the spec's Further Notes) through the new extraction command correctly returns 3 for the multi-entry example and would return 0 for a body with no `Suppressed comments` block
-- [ ] A review body with 0 threads and 0 suppressed comments still routes to Step 8 (clean) exactly as before
+- [x] Step 3 and Step 7 poll logic (SKILL.md) check both thread count and suppressed-comment count before considering the PR reviewed clean
+- [x] REFERENCE.md documents the suppressed-comment count extraction (Step A2) with a runnable command, alongside the existing Step A/B detail
+- [x] The "Loop at a glance" diagram in SKILL.md reflects the new branch
+- [x] Dry-run: piping the real sample review body (from the spec's Further Notes) through the new extraction command correctly returns 3 for the multi-entry example and would return 0 for a body with no `Suppressed comments` block
+- [x] A review body with 0 threads and 0 suppressed comments still routes to Step 8 (clean) exactly as before
 
 ---
 
@@ -36,11 +38,11 @@ Extend Step 4 so each suppressed-comment entry (identified by its bold `**path:l
 
 ### Acceptance criteria (issue 2)
 
-- [ ] SKILL.md Step 4 and REFERENCE.md's "Address each comment" section describe deciding Fix/Push-back per suppressed entry, using the same push-back rule as threads
-- [ ] REFERENCE.md documents suppressed-entry shape (bold path:line header, bullet text, optional fenced code quote) as prose, not a script
-- [ ] SKILL.md and REFERENCE.md explicitly state that suppressed entries are excluded from the Step 4c reply/`resolveReviewThread` mechanism
-- [ ] New Step 4d is documented in SKILL.md (prose + diagram) and REFERENCE.md: posts one PR-level comment per round summarizing every suppressed comment's outcome, fires whenever suppressed comments existed that round regardless of fix/push-back mix, and is skipped when there were none
-- [ ] Loop termination condition 1 in REFERENCE.md (all push-backs, no code changes) is updated to note both thread resolution (Step 4c) and suppressed-comment acknowledgment (Step 4d) happen before the skip to Step 8
-- [ ] Consistency read-through: step numbering (4a/4b/4c/4d), the diagram, and cross-references between SKILL.md and REFERENCE.md all agree
+- [x] SKILL.md Step 4 and REFERENCE.md's "Address each comment" section describe deciding Fix/Push-back per suppressed entry, using the same push-back rule as threads
+- [x] REFERENCE.md documents suppressed-entry shape (bold path:line header, bullet text, optional fenced code quote) as prose, not a script
+- [x] SKILL.md and REFERENCE.md explicitly state that suppressed entries are excluded from the Step 4c reply/`resolveReviewThread` mechanism
+- [x] New Step 4d is documented in SKILL.md (prose + diagram) and REFERENCE.md: posts one PR-level comment per round summarizing every suppressed comment's outcome, fires whenever suppressed comments existed that round regardless of fix/push-back mix, and is skipped when there were none
+- [x] Loop termination condition 1 in REFERENCE.md (all push-backs, no code changes) is updated to note both thread resolution (Step 4c) and suppressed-comment acknowledgment (Step 4d) happen before the skip to Step 8
+- [x] Consistency read-through: step numbering (4a/4b/4c/4d), the diagram, and cross-references between SKILL.md and REFERENCE.md all agree
 
 ---

--- a/.agent-docs/issues/bugfix/address-copilot-suppressed-comments.md
+++ b/.agent-docs/issues/bugfix/address-copilot-suppressed-comments.md
@@ -1,0 +1,46 @@
+# Issues: bugfix/address-copilot-suppressed-comments
+
+## Detect suppressed comments during polling
+
+**GitHub issue**: #39
+
+**Blocked by**: None
+
+**User stories**: 1, 4
+
+### What to build
+
+Add a second check to the Step 3/7 poll (and its final pass after poll exhaustion): fetch the latest Copilot review body and check for a non-zero `### Suppressed comments (N)` block, alongside the existing thread-count check. Either check being non-zero exits the poll to Step 4 instead of declaring the PR clean. Document this in SKILL.md's Step 3 prose and the "Loop at a glance" diagram, and add a "Step A2 — Suppressed comments check" to REFERENCE.md alongside the existing Step A/B detail. The existing thread-count-only path (0 threads, 0 suppressed comments) must keep working exactly as before — no regression to the current clean-declaration behavior when there really is nothing to address.
+
+### Acceptance criteria
+
+- [ ] Step 3 and Step 7 poll logic (SKILL.md) check both thread count and suppressed-comment count before considering the PR reviewed clean
+- [ ] REFERENCE.md documents the suppressed-comment count extraction (Step A2) with a runnable command, alongside the existing Step A/B detail
+- [ ] The "Loop at a glance" diagram in SKILL.md reflects the new branch
+- [ ] Dry-run: piping the real sample review body (from the spec's Further Notes) through the new extraction command correctly returns 3 for the multi-entry example and would return 0 for a body with no `Suppressed comments` block
+- [ ] A review body with 0 threads and 0 suppressed comments still routes to Step 8 (clean) exactly as before
+
+---
+
+## Decide, act on, and acknowledge suppressed comments
+
+**GitHub issue**: #40
+
+**Blocked by**: #39 (needs the poll to route here before there's anything to act on)
+
+**User stories**: 2, 3, 4
+
+### What to build (issue 2)
+
+Extend Step 4 so each suppressed-comment entry (identified by its bold `**path:line**` header and following bullet text) gets the same Fix/Push-back decision as a real thread — including the existing push-back-on-`.agent-docs/`-files rule — but skips the reply/`resolveReviewThread` mechanism, since suppressed entries have no thread or comment ID. Document the entry shape as instructional prose in REFERENCE.md (not a rigid parser), matching how the skill already hands full comment bodies to the agent for real threads. Add a new Step 4d: after Step 4c, if any suppressed comments existed this round, post a single `gh pr comment` summarizing the fix/ignore outcome for each — firing regardless of whether the round's decisions were all push-backs (which otherwise skip Steps 5–7 entirely), since this is the only place a suppressed comment's outcome is ever recorded. Update the loop termination conditions in REFERENCE.md and the "Loop at a glance" diagram to reflect Step 4d.
+
+### Acceptance criteria (issue 2)
+
+- [ ] SKILL.md Step 4 and REFERENCE.md's "Address each comment" section describe deciding Fix/Push-back per suppressed entry, using the same push-back rule as threads
+- [ ] REFERENCE.md documents suppressed-entry shape (bold path:line header, bullet text, optional fenced code quote) as prose, not a script
+- [ ] SKILL.md and REFERENCE.md explicitly state that suppressed entries are excluded from the Step 4c reply/`resolveReviewThread` mechanism
+- [ ] New Step 4d is documented in SKILL.md (prose + diagram) and REFERENCE.md: posts one PR-level comment per round summarizing every suppressed comment's outcome, fires whenever suppressed comments existed that round regardless of fix/push-back mix, and is skipped when there were none
+- [ ] Loop termination condition 1 in REFERENCE.md (all push-backs, no code changes) is updated to note both thread resolution (Step 4c) and suppressed-comment acknowledgment (Step 4d) happen before the skip to Step 8
+- [ ] Consistency read-through: step numbering (4a/4b/4c/4d), the diagram, and cross-references between SKILL.md and REFERENCE.md all agree
+
+---

--- a/.agent-docs/specs/bugfix/address-copilot-suppressed-comments.md
+++ b/.agent-docs/specs/bugfix/address-copilot-suppressed-comments.md
@@ -1,0 +1,75 @@
+# Detect and address Copilot's suppressed comments
+
+## Problem Statement
+
+`address-copilot-comments` drives a loop that fetches Copilot's PR review findings, fixes or pushes back on each one, and declares the PR clean once no unresolved threads remain. GitHub's Copilot reviewer, however, sometimes folds findings into a collapsible `### Suppressed comments (N)` block inside the review body's markdown text instead of posting them as real review threads. Suppressed comments have no `databaseId`/thread ID — they are not real PR review comments, just text inside the review summary — so both the skill's thread-count check (Step 3) and its unresolved-thread fetch (Step 4) are structurally blind to them. A review can report "Comments generated: 0 new" while its body still lists several actionable findings above that line. The skill currently declares the PR clean and merge-ready in this situation, and the PR gets merged with real Copilot findings never seen or addressed.
+
+Confirmed in production: `octopus-monitoring` PR #465, Copilot reviews `4856012639` (round 1 — 1 suppressed comment) and `4856300640` (round 2 — 3 suppressed comments, including one about an issue recurring from round 1). Both rounds the skill reported 0 unresolved threads and declared the PR clean; the PR merged with the suppressed findings unaddressed.
+
+## Solution
+
+Extend the skill's polling and addressing steps to also see and act on suppressed comments, using the same fix-or-push-back decision process as real threads, with an acknowledgment mechanism suited to their lack of an ID:
+
+- The poll (Step 3, and its Step 7 re-poll) checks the latest Copilot review body for a non-zero `### Suppressed comments (N)` block in addition to the existing thread-count check. Either being non-zero routes to Step 4 instead of declaring the PR clean.
+- Step 4 treats each suppressed-comment entry (identified by its bold `**path:line**` header and following bullet text) as its own finding to Fix or Push back on, same as a thread — but skips the reply/resolve mechanism, since there is no thread or comment ID to target.
+- A new Step 4d posts a single PR-level comment (`gh pr comment`) summarizing the fix/ignore outcome for every suppressed comment seen that round. It fires whenever suppressed comments existed that round, regardless of whether the round's decisions were all push-backs or included fixes — this is the only place a suppressed comment's outcome is ever recorded, so it must not be skipped just because no code changed.
+
+## User Stories
+
+1. As a developer running `address-copilot-comments`, I want the skill to notice suppressed Copilot findings even when there are zero unresolved threads, so that the PR is never declared clean while Copilot findings sit unaddressed.
+2. As a developer, I want each suppressed finding fixed or explicitly pushed back on, so that suppressed findings get the same scrutiny as normal review comments.
+3. As a reviewer reading the PR afterward, I want a visible record of what happened to each suppressed finding, so that push-backs on suppressed items are not silently invisible (unlike normal threads, which already carry an inline reply).
+4. As a developer, I want the skill's max-2-review-round cap and all-push-back short-circuit to keep working unchanged when suppressed comments are involved, so that this fix doesn't introduce a new way for the loop to run long or loop indefinitely.
+
+## Implementation Decisions
+
+- **Files changed**: `address-copilot-comments/SKILL.md`, `address-copilot-comments/REFERENCE.md`. No application code — these are the Markdown instructions the skill's own agent loop follows.
+- **Step 3 / Step 7 (poll)**: add a second, deterministic check run alongside the existing thread-count check — fetch the latest Copilot review body (same API call already used to capture the baseline review ID) and grep for `Suppressed comments (N)`, extracting `N`. `N > 0` is treated identically to `thread_count > 0`: exit the poll to Step 4. This applies to both the main poll loop and the final pass performed after poll exhaustion.
+- **REFERENCE.md Step 3 detail**: add a "Step A2 — Suppressed comments check" alongside the existing Step A (thread count) and Step B (new-review-detected) so the reference stays consistent with the poll's actual branching.
+- **Step 4 (address)**: suppressed-comment entries are parsed by the agent reading the review body's markdown directly — instructional prose describing the entry shape (bold `**path:line**` header line, one or more bullet lines of finding text, optional fenced code quoting the affected file content), not a rigid extraction script. This matches how the skill already hands full comment bodies to the agent for real threads, and avoids a brittle parser breaking silently if Copilot's markdown format drifts.
+- **Decision process**: identical Fix/Push-back decision rule as Step 4 already applies to threads (including the existing push-back-on-`.agent-docs/`-files rule). Suppressed entries and thread entries are decided together in the same Step 4 pass.
+- **No reply/resolve for suppressed entries**: Step 4c's per-thread reply + `resolveReviewThread` mutation only applies to real threads (they have the IDs it needs). Suppressed entries are excluded from that step.
+- **Step 4b validation**: unchanged — still runs once per round if at least one fix (thread or suppressed) was applied, covering all of that round's code changes together.
+- **New Step 4d — acknowledge suppressed comments**: after Step 4c, if any suppressed comments existed this round, post one `gh pr comment {number} --body "..."` summarizing the fix/ignore outcome for each. Fires whenever suppressed comments existed that round, independent of the fix/push-back mix — including rounds where every decision (thread and suppressed) was a push-back, which otherwise skip Steps 5–7 entirely. Skipped only when there were zero suppressed comments that round.
+- **Loop termination conditions** (REFERENCE.md): update condition 1 ("all push-backs, no code changes") to note threads are resolved via Step 4c and suppressed comments are acknowledged via Step 4d, regardless of the skip.
+- **"Loop at a glance" diagram** (SKILL.md): update to show the suppressed-comments branch in Step 3/7 and the new Step 4d.
+- **Round cap unchanged**: the existing `review_round >= 2` cap in Step 6 is untouched — suppressed comments are re-evaluated each round from whatever the latest review body contains (no persistent tracking needed, since there's no ID to track against), same as threads.
+
+## Testing Decisions
+
+This is an instruction-only change for an LLM-driven skill — there is no application code, so no unit or integration tests apply. Verification instead:
+
+- **Dry-run the new Step A2 extraction** against the real sample review body from the bug report (the `octopus-monitoring` PR #465 example) to confirm the grep/extraction pipeline correctly reads the suppressed count out of realistic Copilot markdown, including the `<details>`-wrapped, multi-entry case.
+- **Consistency read-through** of the edited `SKILL.md` and `REFERENCE.md`: step numbering stays coherent (4a/4b/4c/4d), the "Loop at a glance" diagram matches the prose steps, and every cross-reference between the two files still resolves.
+
+## Out of Scope
+
+- Changing how real (thread-based) Copilot comments are detected, fetched, replied to, or resolved — that path is unaffected.
+- Building a general-purpose Markdown parser for Copilot review bodies; parsing stays scoped to the one known block shape.
+- Deduplicating suppressed comments across review rounds (e.g. recognizing "this is the same finding as round 1") — each round is evaluated independently against whatever the latest review body contains, same as the existing thread flow, bounded by the existing 2-round cap.
+- Any change to `pr-cleanup`, `code-review`, or other skills downstream of `address-copilot-comments`.
+
+## Further Notes
+
+Real suppressed-comment markdown example (from `gh api repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | select(.user.login | test("copilot";"i")) | .body'`), used as the dry-run fixture:
+
+```markdown
+### 🟡 Not ready to approve
+...
+<details>
+<summary>Review details</summary>
+
+### Suppressed comments (3)
+
+**grafana/mariadb/queries.md:158**
+* The Agile Prices threshold description uses pound symbols... mixes currencies...
+<quoted file context>
+
+**grafana/dashboard.json:1021**
+* Panel id 13 omits the `title` field entirely...
+<quoted file context>
+
+Comments generated: 0 new
+Review effort level: Lite
+</details>
+```

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -45,9 +45,7 @@ query {
 }' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | test("copilot"; "i"))] | length'
 ```
 
-If count > 0 — exit the poll loop and continue to Step 4.
-
-**Step A2 — Suppressed comments check.** Fetch the latest Copilot review body and check for a `### Suppressed comments (N)` block:
+**Step A2 — Suppressed comments check.** Run every iteration alongside Step A — do not skip this because Step A already found threads. A round can have both real threads and suppressed comments at once, and Step 4 relies on this check having actually run to know about any suppressed entries. Fetch the latest Copilot review body and check for a `### Suppressed comments (N)` block:
 
 ```bash
 REVIEW_BODY=$(gh api "repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100" \
@@ -57,7 +55,9 @@ SUPPRESSED_COUNT=$(echo "$REVIEW_BODY" | grep -oE 'Suppressed comments \([0-9]+\
 SUPPRESSED_COUNT=${SUPPRESSED_COUNT:-0}
 ```
 
-If `SUPPRESSED_COUNT` > 0 — exit the poll loop and continue to Step 4. Suppressed comments have no `databaseId`/thread ID — they are markdown text embedded in the review body's collapsible `<details>` block (GitHub's Copilot reviewer folds some findings there instead of posting them as real review comments), not real PR review comments, so they never appear as `reviewThreads` and Step A's count reads 0 even when these exist.
+Suppressed comments have no `databaseId`/thread ID — they are markdown text embedded in the review body's collapsible `<details>` block (GitHub's Copilot reviewer folds some findings there instead of posting them as real review comments), not real PR review comments, so they never appear as `reviewThreads` and Step A's count reads 0 even when these exist.
+
+**Decision.** If the Step A count > 0 **or** `SUPPRESSED_COUNT` > 0 — exit the poll loop and continue to Step 4, carrying forward `$REVIEW_BODY` for Step 4's suppressed-entry handling.
 
 **Step B — Reviews check (only when thread count = 0 and suppressed count = 0).** Check whether the latest Copilot review ID has changed since the baseline was captured. This re-fetches the same reviews endpoint as Step A2 rather than reusing its result — `gh api --jq` uses `gh`'s bundled jq internally, but combining Step A2 and Step B's extractions into a single call would require piping through a standalone `jq` binary, which isn't guaranteed to be on `PATH` even where `gh` is. The extra request is the safer trade:
 

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -51,7 +51,7 @@ query {
 REVIEW_BODY=$(gh api "repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100" \
   --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .body // empty')
 
-SUPPRESSED_COUNT=$(echo "$REVIEW_BODY" | grep -oE 'Suppressed comments \([0-9]+\)' | grep -oE '[0-9]+' | head -1)
+SUPPRESSED_COUNT=$(printf '%s' "$REVIEW_BODY" | grep -oE 'Suppressed comments \([0-9]+\)' | grep -oE '[0-9]+' | head -1)
 SUPPRESSED_COUNT=${SUPPRESSED_COUNT:-0}
 ```
 

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -111,6 +111,12 @@ The query returns two IDs per thread — use the right one for each operation:
 - `threadId` (`PRRT_...` node ID) — used with `resolveReviewThread` GraphQL mutation
 - `comment_id` (numeric `databaseId`) — used with the REST reply endpoint below
 
+### Suppressed comments (no thread ID)
+
+Suppressed comments come from the same review body already fetched in Step A2 (`$REVIEW_BODY`) — re-fetch it here if it's out of scope. Read the `### Suppressed comments (N)` block directly rather than parsing it with a script: each entry starts with a bold `**path:line**` header line, followed by one or more `*` bullet lines with the finding text, and optionally a fenced code block quoting the affected file content. Treat each entry as its own finding — decide Fix or Push back exactly as for a thread (including the `.agent-docs/` push-back rule), and apply any code changes the same way.
+
+Suppressed entries have no `threadId` or `comment_id` — the reply and resolve steps below apply only to real threads. Skip straight to the "Acknowledge suppressed comments" section for these instead.
+
 ### Reply: fixed
 
 ```bash
@@ -160,6 +166,22 @@ mutation {
   }
 }'
 ```
+
+### Acknowledge suppressed comments — Step 4d
+
+Suppressed comments have no per-comment reply target, so post one PR-level comment covering all of this round's suppressed entries once Fix/Push-back decisions have been made for the round — same timing as Step 4c's thread replies, before Step 5 commits and pushes:
+
+```bash
+gh pr comment {number} --body "$(cat <<'EOF'
+Addressed this round's suppressed Copilot comments:
+
+- path/to/file.md:158 — Fixed. <one-line explanation>
+- path/to/other.json:1021 — Ignored. <reason>
+EOF
+)"
+```
+
+One line per suppressed entry, same "Fixed."/"Ignored." phrasing used for thread replies. Post this whenever suppressed comments existed this round, even if every decision (threads and suppressed comments together) was a push-back — see Loop termination conditions below.
 
 ---
 
@@ -212,8 +234,8 @@ gh api repos/{owner}/{repo}/pulls/{number} --jq '.node_id'
 
 The loop is complete when **any** of these conditions is met:
 
-1. **All push-backs in a round** — no code changes were made. Threads are already resolved after Step 4c. Skip Steps 5–7; do not re-trigger Copilot. PR is ready to merge.
+1. **All push-backs in a round** — no code changes were made. Threads are already resolved after Step 4c, and any suppressed comments are already acknowledged via the PR-level comment posted in Step 4d. Skip Steps 5–7; do not re-trigger Copilot. PR is ready to merge.
 2. **Max reviews reached** — `review_round >= 2` at Step 6. Do not re-trigger. PR is ready to merge.
-3. **Clean review or poll exhausted** — the Step 3 poll (or Step 7 re-poll) ends with zero unresolved threads. Either a new Copilot review was detected with no comments (exits immediately to Step 8), or 10 attempts elapsed with no new review (falls through to Step 8).
+3. **Clean review or poll exhausted** — the Step 3 poll (or Step 7 re-poll) ends with zero unresolved threads and zero suppressed comments. Either a new Copilot review was detected with no comments (exits immediately to Step 8), or 10 attempts elapsed with no new review (falls through to Step 8).
 
 In all cases the PR is considered clean and ready to merge.

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -59,7 +59,7 @@ SUPPRESSED_COUNT=${SUPPRESSED_COUNT:-0}
 
 If `SUPPRESSED_COUNT` > 0 — exit the poll loop and continue to Step 4. Suppressed comments have no `databaseId`/thread ID — they are markdown text embedded in the review body's collapsible `<details>` block (GitHub's Copilot reviewer folds some findings there instead of posting them as real review comments), not real PR review comments, so they never appear as `reviewThreads` and Step A's count reads 0 even when these exist.
 
-**Step B — Reviews check (only when thread count = 0 and suppressed count = 0).** Check whether the latest Copilot review ID has changed since the baseline was captured:
+**Step B — Reviews check (only when thread count = 0 and suppressed count = 0).** Check whether the latest Copilot review ID has changed since the baseline was captured. This re-fetches the same reviews endpoint as Step A2 rather than reusing its result — `gh api --jq` uses `gh`'s bundled jq internally, but combining Step A2 and Step B's extractions into a single call would require piping through a standalone `jq` binary, which isn't guaranteed to be on `PATH` even where `gh` is. The extra request is the safer trade:
 
 ```bash
 # Same query as baseline capture above — assigns to CURRENT_REVIEW_ID
@@ -77,7 +77,7 @@ After 10 failed attempts (thread count still 0, suppressed count still 0, and no
 
 ---
 
-## Step 4 — Address each comment
+## Step 4 — Address each comment and suppressed entry
 
 ### Fetch all unresolved Copilot review threads
 
@@ -167,7 +167,7 @@ mutation {
 }'
 ```
 
-### Acknowledge suppressed comments — Step 4d
+### Acknowledge suppressed comments
 
 Suppressed comments have no per-comment reply target, so post one PR-level comment covering all of this round's suppressed entries once Fix/Push-back decisions have been made for the round — same timing as Step 4c's thread replies, before Step 5 commits and pushes:
 

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -4,7 +4,7 @@ Full command detail for each step. Replace `{owner}`, `{repo}`, `{number}`, `{id
 
 ---
 
-## Step 3 — Poll for Copilot review threads
+## Step 3 — Poll for Copilot review threads and suppressed comments
 
 Get `{owner}/{repo}` from:
 
@@ -47,7 +47,19 @@ query {
 
 If count > 0 — exit the poll loop and continue to Step 4.
 
-**Step B — Reviews check (only when thread count = 0).** Check whether the latest Copilot review ID has changed since the baseline was captured:
+**Step A2 — Suppressed comments check.** Fetch the latest Copilot review body and check for a `### Suppressed comments (N)` block:
+
+```bash
+REVIEW_BODY=$(gh api "repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100" \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .body // empty')
+
+SUPPRESSED_COUNT=$(echo "$REVIEW_BODY" | grep -oE 'Suppressed comments \([0-9]+\)' | grep -oE '[0-9]+' | head -1)
+SUPPRESSED_COUNT=${SUPPRESSED_COUNT:-0}
+```
+
+If `SUPPRESSED_COUNT` > 0 — exit the poll loop and continue to Step 4. Suppressed comments have no `databaseId`/thread ID — they are markdown text embedded in the review body's collapsible `<details>` block (GitHub's Copilot reviewer folds some findings there instead of posting them as real review comments), not real PR review comments, so they never appear as `reviewThreads` and Step A's count reads 0 even when these exist.
+
+**Step B — Reviews check (only when thread count = 0 and suppressed count = 0).** Check whether the latest Copilot review ID has changed since the baseline was captured:
 
 ```bash
 # Same query as baseline capture above — assigns to CURRENT_REVIEW_ID
@@ -61,7 +73,7 @@ If `CURRENT_REVIEW_ID` is non-empty and differs from `BASELINE_REVIEW_ID` — Co
 
 If `CURRENT_REVIEW_ID` equals `BASELINE_REVIEW_ID` (or is still empty) — no new review yet. Wait 60 seconds and repeat.
 
-After 10 failed attempts (thread count still 0 and no new review detected), perform one final pass of Steps A and B with the same queries. If the final pass also returns 0 threads and no new review, Copilot has not yet reviewed or has nothing actionable — continue to Step 8.
+After 10 failed attempts (thread count still 0, suppressed count still 0, and no new review detected), perform one final pass of Steps A, A2, and B with the same queries. If the final pass also returns 0 threads, 0 suppressed comments, and no new review, Copilot has not yet reviewed or has nothing actionable — continue to Step 8.
 
 ---
 

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -21,10 +21,11 @@ Step 3  Record baseline Copilot review ID; poll every 60s:
         both 0 + new Copilot review (IDs differ)? ───────────────────► Step 8 (reviewed clean)
         Poll exhausted? one final pass: threads > 0 or suppressed > 0? ► Step 4
                         final pass: both 0, no new review? ──────────► Step 8
-Step 4  For each unresolved thread: decide fix or push-back; apply code changes
+Step 4  For each unresolved thread and each suppressed-comment entry: decide fix or push-back; apply code changes
 Step 4b Run code-review (Steps 1–5 only; skip code-review Step 6) to validate changes
 Step 4c Reply to each thread ("Fixed." / "Ignored.") → resolve thread immediately
-        All push-backs? ──Yes──► Step 8 (skip Steps 5–7)
+Step 4d Suppressed comments this round? ──Yes──► post one PR comment summarizing fix/ignore outcomes
+        All push-backs (threads + suppressed)? ──Yes──► Step 8 (skip Steps 5–7)
 Step 5  Execute pre-commit-checks or .git/hooks/pre-commit (if any) → commit → push
 Step 6  review_round < 2? ──Yes──► review_round++; re-trigger Copilot → Step 7
                           ──No ──► Step 8 (max 2 reviews; do not re-trigger)
@@ -75,7 +76,7 @@ After 10 attempts with no new clean review, perform one final check following th
 
 ## Step 4 — Decide and apply changes
 
-For each unresolved thread decide **Fix** or **Push back** (push back on any file contained within `.agent-docs/` — Copilot is not a domain expert there); apply code changes; see the Address Each Comment section in [REFERENCE.md](REFERENCE.md) for fetch query and reply commands.
+For each unresolved thread, and each suppressed-comment entry found in Step 3/7, decide **Fix** or **Push back** (push back on any file contained within `.agent-docs/` — Copilot is not a domain expert there); apply code changes; see the Address Each Comment section in [REFERENCE.md](REFERENCE.md) for fetch query, reply commands, and how to read suppressed-comment entries out of the review body.
 
 ## Step 4b — Validate changes with code-review
 
@@ -89,7 +90,13 @@ File type is not a skip condition.
 
 ## Step 4c — Reply and resolve threads
 
-Reply to each thread ("Fixed. ..." or "Ignored. ...") and immediately resolve via GraphQL — see the Address Each Comment section in [REFERENCE.md](REFERENCE.md) for the `resolveReviewThread` mutation. All push-backs → skip to Step 8; at least one fix → continue to Step 5.
+Reply to each **thread** ("Fixed. ..." or "Ignored. ...") and immediately resolve via GraphQL — see the Address Each Comment section in [REFERENCE.md](REFERENCE.md) for the `resolveReviewThread` mutation. This step applies only to real threads — suppressed-comment entries have no thread or comment ID, so there is nothing to reply to or resolve; they are acknowledged instead in Step 4d.
+
+## Step 4d — Acknowledge suppressed comments
+
+If any suppressed-comment entries were found in Step 3/7 this round, post a single PR-level comment summarizing the fix/ignore outcome for every one of them — see the Address Each Comment section in [REFERENCE.md](REFERENCE.md) for the `gh pr comment` command. Post this regardless of whether this round's decisions (threads and suppressed comments together) were all push-backs — it's the only record of a suppressed comment's outcome, since it has no per-comment reply target. Skip this step entirely if there were no suppressed comments this round.
+
+All push-backs across both threads and suppressed comments, and zero files modified → skip to Step 8 (skip Steps 5–7). At least one fix → continue to Step 5.
 
 ## Step 5 — Commit and push
 

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -72,11 +72,11 @@ Poll every 60 seconds, max 10 attempts:
 3. If both checks are 0/absent, check whether the latest Copilot review ID is non-empty and differs from the baseline. If yes, Copilot reviewed clean — go to Step 8 immediately.
 4. If no new review, wait and repeat.
 
-After 10 attempts with no new clean review, perform one final check following the same branching: threads > 0 or suppressed comments > 0 → exit to Step 4; otherwise go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for the queries.
+After 10 attempts with no new clean review, perform one final check following the same branching: threads > 0 or suppressed comments > 0 → exit to Step 4; otherwise go to Step 8. See the Poll for Copilot Review Threads and Suppressed Comments section in [REFERENCE.md](REFERENCE.md) for the queries.
 
 ## Step 4 — Decide and apply changes
 
-For each unresolved thread, and each suppressed-comment entry found in Step 3/7, decide **Fix** or **Push back** (push back on any file contained within `.agent-docs/` — Copilot is not a domain expert there); apply code changes; see the Address Each Comment section in [REFERENCE.md](REFERENCE.md) for fetch query, reply commands, and how to read suppressed-comment entries out of the review body.
+For each unresolved thread, and each suppressed-comment entry found in Step 3/7, decide **Fix** or **Push back** (push back on any file contained within `.agent-docs/` — Copilot is not a domain expert there); apply code changes; see the Address Each Comment and Suppressed Entry section in [REFERENCE.md](REFERENCE.md) for fetch query, reply commands, and how to read suppressed-comment entries out of the review body.
 
 ## Step 4b — Validate changes with code-review
 
@@ -90,11 +90,11 @@ File type is not a skip condition.
 
 ## Step 4c — Reply and resolve threads
 
-Reply to each **thread** ("Fixed. ..." or "Ignored. ...") and immediately resolve via GraphQL — see the Address Each Comment section in [REFERENCE.md](REFERENCE.md) for the `resolveReviewThread` mutation. This step applies only to real threads — suppressed-comment entries have no thread or comment ID, so there is nothing to reply to or resolve; they are acknowledged instead in Step 4d.
+Reply to each **thread** ("Fixed. ..." or "Ignored. ...") and immediately resolve via GraphQL — see the Address Each Comment and Suppressed Entry section in [REFERENCE.md](REFERENCE.md) for the `resolveReviewThread` mutation. This step applies only to real threads — suppressed-comment entries have no thread or comment ID, so there is nothing to reply to or resolve; they are acknowledged instead in Step 4d.
 
 ## Step 4d — Acknowledge suppressed comments
 
-If any suppressed-comment entries were found in Step 3/7 this round, post a single PR-level comment summarizing the fix/ignore outcome for every one of them — see the Address Each Comment section in [REFERENCE.md](REFERENCE.md) for the `gh pr comment` command. Post this regardless of whether this round's decisions (threads and suppressed comments together) were all push-backs — it's the only record of a suppressed comment's outcome, since it has no per-comment reply target. Skip this step entirely if there were no suppressed comments this round.
+If any suppressed-comment entries were found in Step 3/7 this round, post a single PR-level comment summarizing the fix/ignore outcome for every one of them — see the Address Each Comment and Suppressed Entry section in [REFERENCE.md](REFERENCE.md) for the `gh pr comment` command. Post this regardless of whether this round's decisions (threads and suppressed comments together) were all push-backs — it's the only record of a suppressed comment's outcome, since it has no per-comment reply target. Skip this step entirely if there were no suppressed comments this round.
 
 All push-backs across both threads and suppressed comments, and zero files modified → skip to Step 8 (skip Steps 5–7). At least one fix → continue to Step 5.
 

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -17,9 +17,10 @@ Step 1  PR exists? ──No──► Step 2: create PR (review_round = 1)
         PR exists? ──Yes──► review_round = 1
 Step 3  Record baseline Copilot review ID; poll every 60s:
         thread count > 0? ─────────────────────────────────────────► Step 4
-        thread count = 0 + new Copilot review (IDs differ)? ───────► Step 8 (reviewed clean)
-        Poll exhausted? one final pass: threads > 0? ─────────────► Step 4
-                        final pass: 0 threads, no new review? ──► Step 8
+        suppressed comments > 0 in latest review body? ─────────────► Step 4
+        both 0 + new Copilot review (IDs differ)? ───────────────────► Step 8 (reviewed clean)
+        Poll exhausted? one final pass: threads > 0 or suppressed > 0? ► Step 4
+                        final pass: both 0, no new review? ──────────► Step 8
 Step 4  For each unresolved thread: decide fix or push-back; apply code changes
 Step 4b Run code-review (Steps 1–5 only; skip code-review Step 6) to validate changes
 Step 4c Reply to each thread ("Fixed." / "Ignored.") → resolve thread immediately
@@ -28,7 +29,7 @@ Step 5  Execute pre-commit-checks or .git/hooks/pre-commit (if any) → commit �
 Step 6  review_round < 2? ──Yes──► review_round++; re-trigger Copilot → Step 7
                           ──No ──► Step 8 (max 2 reviews; do not re-trigger)
 Step 7  Re-capture baseline; poll as in Step 3:
-        threads? ──► Step 4 | clean or exhausted? ──► Step 8
+        threads or suppressed comments? ──► Step 4 | clean or exhausted? ──► Step 8
 Step 8  Report PR link — PR is ready to merge
 ```
 
@@ -59,17 +60,18 @@ gh pr create --base "$BASE" --title "<title>" --body "<summary and test plan>"
 
 Note the PR number. Set `review_round = 1`. The first Copilot review triggers automatically.
 
-## Step 3 — Poll for Copilot review threads
+## Step 3 — Poll for Copilot review threads and suppressed comments
 
 Before polling, capture the latest Copilot review ID as a baseline (empty if no review exists yet).
 
 Poll every 60 seconds, max 10 attempts:
 
 1. Run the thread count check. If > 0, exit to Step 4.
-2. If 0, check whether the latest Copilot review ID is non-empty and differs from the baseline. If yes, Copilot reviewed clean — go to Step 8 immediately.
-3. If no new review, wait and repeat.
+2. Fetch the latest Copilot review body and check for a `### Suppressed comments (N)` block with N > 0. If found, exit to Step 4. Suppressed comments are actionable Copilot findings folded into the review body's markdown instead of posted as real reviewThreads — they have no `databaseId`/thread ID, so they never show up in the thread count check even though they're unaddressed.
+3. If both checks are 0/absent, check whether the latest Copilot review ID is non-empty and differs from the baseline. If yes, Copilot reviewed clean — go to Step 8 immediately.
+4. If no new review, wait and repeat.
 
-After 10 attempts with no new clean review, perform one final check following the same branching: threads > 0 → exit to Step 4; otherwise go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for the queries.
+After 10 attempts with no new clean review, perform one final check following the same branching: threads > 0 or suppressed comments > 0 → exit to Step 4; otherwise go to Step 8. See the Poll for Copilot Review Threads section in [REFERENCE.md](REFERENCE.md) for the queries.
 
 ## Step 4 — Decide and apply changes
 
@@ -97,9 +99,9 @@ Stage files explicitly (`git add <file1> <file2> ...`), commit with `"address Co
 
 If `review_round >= 2`, skip to Step 8. Otherwise increment to 2 and re-trigger via `gh pr edit {number} --add-reviewer @copilot`. See the Re-trigger Copilot Review section in [REFERENCE.md](REFERENCE.md) if that command fails.
 
-## Step 7 — Check for new threads
+## Step 7 — Check for new threads and suppressed comments
 
-Re-capture the baseline Copilot review ID, then poll as in Step 3. New unresolved threads → return to Step 4. None (or clean review detected) → continue to Step 8.
+Re-capture the baseline Copilot review ID, then poll as in Step 3. New unresolved threads or suppressed comments → return to Step 4. Neither (or clean review detected) → continue to Step 8.
 
 ## Step 8 — Report completion
 

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -67,10 +67,9 @@ Before polling, capture the latest Copilot review ID as a baseline (empty if no 
 
 Poll every 60 seconds, max 10 attempts:
 
-1. Run the thread count check. If > 0, exit to Step 4.
-2. Fetch the latest Copilot review body and check for a `### Suppressed comments (N)` block with N > 0. If found, exit to Step 4. Suppressed comments are actionable Copilot findings folded into the review body's markdown instead of posted as real reviewThreads — they have no `databaseId`/thread ID, so they never show up in the thread count check even though they're unaddressed.
-3. If both checks are 0/absent, check whether the latest Copilot review ID is non-empty and differs from the baseline. If yes, Copilot reviewed clean — go to Step 8 immediately.
-4. If no new review, wait and repeat.
+1. Run the thread count check **and** the suppressed-comments check (both, every iteration — don't short-circuit one on the other, a round can have both real threads and suppressed comments at once). If either is non-zero, exit to Step 4. Suppressed comments are actionable Copilot findings folded into the review body's markdown instead of posted as real reviewThreads — they have no `databaseId`/thread ID, so they never show up in the thread count check even though they're unaddressed.
+2. If both checks are 0/absent, check whether the latest Copilot review ID is non-empty and differs from the baseline. If yes, Copilot reviewed clean — go to Step 8 immediately.
+3. If no new review, wait and repeat.
 
 After 10 attempts with no new clean review, perform one final check following the same branching: threads > 0 or suppressed comments > 0 → exit to Step 4; otherwise go to Step 8. See the Poll for Copilot Review Threads and Suppressed Comments section in [REFERENCE.md](REFERENCE.md) for the queries.
 


### PR DESCRIPTION
## Summary

`address-copilot-comments` only ever saw real GraphQL reviewThreads. GitHub's Copilot reviewer sometimes folds findings into a collapsible `### Suppressed comments (N)` block in the review body's markdown instead, with no thread/comment ID — these were structurally invisible to the skill's polling and addressing logic, so a PR could be declared clean and merged while real Copilot findings sat unaddressed above the "Comments generated: 0 new" line.

Confirmed in production: `octopus-monitoring` PR #465, two review rounds with 1 and 3 suppressed comments respectively, both times reported as "0 unresolved threads" and merged clean.

- Poll (Step 3/7) now checks the review body for a non-zero `Suppressed comments (N)` block alongside the thread count, with both checks running unconditionally every iteration (closes a coverage gap where the thread check used to short-circuit before the suppressed check ran).
- Step 4 decides Fix/Push-back on each suppressed entry the same way as a thread, but skips the reply/resolve mechanism (no ID to target).
- New Step 4d posts one PR-level comment summarizing the fix/ignore outcome for every suppressed comment that round — fires regardless of push-back mix, since it's the only record of a suppressed comment's outcome.

Closes #39, closes #40.

## Test plan

- [x] Dry-ran the suppressed-count extraction against the real sample Copilot review body from the bug report — correctly returns 3 for the multi-entry case, 0 for a clean review.
- [x] Two independent, fresh two-axis (Standards + Spec) review passes came back with zero findings after fixing all issues surfaced along the way (a redundant/risky standalone-`jq` dependency, stale cross-references, and a real coverage gap in the poll's short-circuit logic).
- [x] Full consistency read-through of SKILL.md's "Loop at a glance" diagram against both files' step-by-step prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)