### PR TITLE
Add Step 2b review-required decisioning to address-copilot-comments

### DIFF
--- a/.agent-docs/adr/0004-explicit-copilot-trigger-gated-by-review-required-diff.md
+++ b/.agent-docs/adr/0004-explicit-copilot-trigger-gated-by-review-required-diff.md
@@ -1,0 +1,8 @@
+# Explicitly trigger Copilot review, gated by a content-based review-required check
+
+GitHub no longer auto-triggers a Copilot review on PR creation — `address-copilot-comments` Step 2 previously relied on that ("the first Copilot review triggers automatically"). We now trigger it ourselves at a new Step 2b, but only when the diff is judged a [[review-required diff]]: functional code or skill step-logic changes require review; prose-only docs, no-logic config, and formatting-only diffs are exempt and skip straight to Step 8 with no `review_round` consumed. The check reads diff *content* (`gh pr diff`), not file extension, because this repo's skills are `.md` files whose prose and executable step logic share an extension.
+
+## Considered Options
+
+- **Always trigger unconditionally**, matching the old auto-trigger's blanket behavior. Rejected: this repo's own changes are frequently docs/spec/issue-only (`.agent-docs/`), and burning a Copilot review round on every one of those wastes the 2-round cap on PRs that have nothing for Copilot to review.
+- **Classify by file extension alone** (`.md` = docs, exempt). Rejected: would let a broken `SKILL.md`/`REFERENCE.md` step-logic edit — the actual "code" in this repo — through with no review, since it shares an extension with genuinely prose-only files like `context.md`.

--- a/.agent-docs/adr/0004-explicit-copilot-trigger-gated-by-review-required-diff.md
+++ b/.agent-docs/adr/0004-explicit-copilot-trigger-gated-by-review-required-diff.md
@@ -1,6 +1,6 @@
 # Explicitly trigger Copilot review, gated by a content-based review-required check
 
-GitHub no longer auto-triggers a Copilot review on PR creation — `address-copilot-comments` Step 2 previously relied on that ("the first Copilot review triggers automatically"). We now trigger it ourselves at a new Step 2b, but only when the diff is judged a [[review-required diff]]: functional code or skill step-logic changes require review; prose-only docs, no-logic config, and formatting-only diffs are exempt and skip straight to Step 8 with no `review_round` consumed. The check reads diff *content* (`gh pr diff`), not file extension, because this repo's skills are `.md` files whose prose and executable step logic share an extension.
+GitHub no longer auto-triggers a Copilot review on PR creation — `address-copilot-comments` Step 2 previously relied on that ("the first Copilot review triggers automatically"). We now trigger it ourselves at a new Step 2b, but only when the diff is judged a "review-required diff" (see `.agent-docs/context.md`): functional code or skill step-logic changes require review; prose-only docs, no-logic config, and formatting-only diffs are exempt and skip straight to Step 8 with no `review_round` consumed. The check reads diff *content* (`gh pr diff`), not file extension, because this repo's skills are `.md` files whose prose and executable step logic share an extension.
 
 ## Considered Options
 

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -48,6 +48,10 @@ _Avoid_: temp branch, scratch branch
 In `address-copilot-comments`, a counter tracking how many times Copilot has been requested to review a PR. Capped at 2; incrementing past the cap skips re-triggering.
 _Avoid_: review iteration, Copilot attempt, pass
 
+**Review-required diff**:
+The judgment `address-copilot-comments` Step 2b makes about whether a PR's diff needs an initial Copilot review — based on diff content, not file extension. Functional code changes and skill step-logic edits (commands, decisioning, mutations in `SKILL.md`/`REFERENCE.md`) require review; prose-only documentation, no-logic config, and formatting-only diffs are exempt.
+_Avoid_: complex change, non-trivial diff, code change
+
 **Unresolved thread**:
 A PR review comment thread that has not yet been marked resolved via GitHub's `resolveReviewThread` GraphQL mutation.
 _Avoid_: open comment, pending thread, active comment

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -49,7 +49,7 @@ In `address-copilot-comments`, a counter tracking how many times Copilot has bee
 _Avoid_: review iteration, Copilot attempt, pass
 
 **Review-required diff**:
-The judgment `address-copilot-comments` Step 2b makes about whether a PR's diff needs an initial Copilot review — based on diff content, not file extension. Functional code changes and skill step-logic edits (commands, decisioning, mutations in `SKILL.md`/`REFERENCE.md`) require review; prose-only documentation, no-logic config, and formatting-only diffs are exempt.
+The judgment `address-copilot-comments` Step 2b makes about whether a PR's diff needs an initial Copilot review — based on diff content, not file extension. Functional code changes and skill step-logic edits (commands, decisioning, mutations in `SKILL.md`/`REFERENCE.md`/`WORKFLOW.md`) require review; prose-only documentation, no-logic config, and formatting-only diffs are exempt.
 _Avoid_: complex change, non-trivial diff, code change
 
 **Unresolved thread**:

--- a/.agent-docs/issues/chore/address-copilot-review-trigger-decisioning.md
+++ b/.agent-docs/issues/chore/address-copilot-review-trigger-decisioning.md
@@ -1,5 +1,7 @@
 # Issues: chore/address-copilot-review-trigger-decisioning
 
+> Work complete — PR ready to merge.
+
 ## Add Step 2b review-required decisioning to address-copilot-comments
 
 **GitHub issue**: #42
@@ -20,11 +22,11 @@ Remove Step 1/2's unconditional `review_round = 1` and Step 2's now-false "the f
 
 ### Acceptance criteria
 
-- [ ] Given a PR whose diff is entirely within `.agent-docs/`, when Step 2b runs, then it classifies as exempt and skips straight to Step 8 without triggering or polling.
-- [ ] Given a PR whose diff includes a step-logic edit to `SKILL.md`/`REFERENCE.md`, when Step 2b runs, then it classifies as review-required, triggers Copilot, sets `review_round = 1`, and continues to Step 3.
-- [ ] Given a PR whose diff mixes exempt files with one functional code file, when Step 2b runs, then it classifies as review-required (not every file exempt).
-- [ ] Given a review-required PR completes round 1 with unresolved threads, when Step 6 runs, then it still re-triggers for round 2, unaffected by Step 2b.
-- [ ] The "Loop at a glance" diagram reflects the new Step 2b branch.
-- [ ] `REFERENCE.md` documents the `gh pr diff` command and classification rule without duplicating Step 6's trigger command section.
+- [x] Given a PR whose diff is entirely within `.agent-docs/`, when Step 2b runs, then it classifies as exempt and skips straight to Step 8 without triggering or polling.
+- [x] Given a PR whose diff includes a step-logic edit to `SKILL.md`/`REFERENCE.md`, when Step 2b runs, then it classifies as review-required, triggers Copilot, sets `review_round = 1`, and continues to Step 3.
+- [x] Given a PR whose diff mixes exempt files with one functional code file, when Step 2b runs, then it classifies as review-required (not every file exempt).
+- [x] Given a review-required PR completes round 1 with unresolved threads, when Step 6 runs, then it still re-triggers for round 2, unaffected by Step 2b.
+- [x] The "Loop at a glance" diagram reflects the new Step 2b branch.
+- [x] `REFERENCE.md` documents the `gh pr diff` command and classification rule without duplicating Step 6's trigger command section.
 
 ---

--- a/.agent-docs/issues/chore/address-copilot-review-trigger-decisioning.md
+++ b/.agent-docs/issues/chore/address-copilot-review-trigger-decisioning.md
@@ -1,0 +1,30 @@
+# Issues: chore/address-copilot-review-trigger-decisioning
+
+## Add Step 2b review-required decisioning to address-copilot-comments
+
+**GitHub issue**: #42
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3, 4
+
+### What to build
+
+A new Step 2b in `address-copilot-comments/SKILL.md`, inserted after Step 1/2 (PR exists/create) and before Step 3's poll loop, that decides from the PR's diff content (`gh pr diff {number}`) whether an initial Copilot review is required, and explicitly triggers one when it is — replacing the auto-trigger assumption GitHub no longer honors.
+
+Classify by content, not file extension: functional code changes or `SKILL.md`/`REFERENCE.md` step-logic edits (commands, decisioning, mutations, branching) are review-required; prose-only docs, no-logic config, and formatting-only diffs are exempt. A diff is exempt overall only if every changed file is exempt.
+
+Not required → skip straight to Step 8, no poll, no `review_round` set. Required → trigger via the same mechanism Step 6 already uses, set `review_round = 1`, continue to Step 3.
+
+Remove Step 1/2's unconditional `review_round = 1` and Step 2's now-false "the first Copilot review triggers automatically" line. Update the "Loop at a glance" diagram to show the new branch. Add a `REFERENCE.md` section documenting the `gh pr diff` command and the classification rule, cross-referenced from Step 2b and reusing (not duplicating) Step 6's existing trigger section.
+
+### Acceptance criteria
+
+- [ ] Given a PR whose diff is entirely within `.agent-docs/`, when Step 2b runs, then it classifies as exempt and skips straight to Step 8 without triggering or polling.
+- [ ] Given a PR whose diff includes a step-logic edit to `SKILL.md`/`REFERENCE.md`, when Step 2b runs, then it classifies as review-required, triggers Copilot, sets `review_round = 1`, and continues to Step 3.
+- [ ] Given a PR whose diff mixes exempt files with one functional code file, when Step 2b runs, then it classifies as review-required (not every file exempt).
+- [ ] Given a review-required PR completes round 1 with unresolved threads, when Step 6 runs, then it still re-triggers for round 2, unaffected by Step 2b.
+- [ ] The "Loop at a glance" diagram reflects the new Step 2b branch.
+- [ ] `REFERENCE.md` documents the `gh pr diff` command and classification rule without duplicating Step 6's trigger command section.
+
+---

--- a/.agent-docs/specs/chore/address-copilot-review-trigger-decisioning.md
+++ b/.agent-docs/specs/chore/address-copilot-review-trigger-decisioning.md
@@ -1,0 +1,48 @@
+# Copilot Review Trigger Decisioning
+
+## Problem Statement
+
+`address-copilot-comments` Step 2 assumes "the first Copilot review triggers automatically" when a PR is created. GitHub no longer auto-triggers a Copilot review on PR creation, so this assumption is false: the skill would create a PR, then poll forever (or until exhaustion) for a review that was never requested.
+
+## Solution
+
+Add a new Step 2b that decides, from the PR's diff content, whether the PR needs an initial Copilot review at all, and explicitly requests one when it does — replacing the auto-trigger the skill used to rely on. PRs limited to prose documentation, no-logic config, or trivial/formatting changes skip the trigger and the poll loop entirely; PRs with functional code or skill step-logic changes get an explicit review request before Step 3's poll begins.
+
+## User Stories
+
+1. As an agent running `address-copilot-comments` on a PR with functional or step-logic changes, I want the skill to explicitly request a Copilot review, so that the review loop still runs even though GitHub no longer triggers it automatically.
+2. As an agent running `address-copilot-comments` on a docs-only or config-only PR, I want the skill to skip the review request and poll, so that trivial PRs aren't held up waiting for a review that has nothing to check.
+3. As a maintainer of this skills repo, I want the review-required decision made from diff content rather than file extension, so that a `SKILL.md`/`REFERENCE.md` step-logic edit — this repo's actual "code" — isn't misclassified as documentation just because it's a `.md` file.
+4. As a caller of `address-copilot-comments` (`code-review` Step 6, `implement` `WORKFLOW.md`), I want the loop to still terminate with the PR reported ready either way, so that the new decisioning doesn't change the skill's external contract.
+
+## Implementation Decisions
+
+- New **Step 2b — Decide whether Copilot review is required**, inserted in `address-copilot-comments/SKILL.md` after Step 1/2 (a PR number is guaranteed to exist by this point) and before Step 3's poll loop.
+- Reads the full diff via `gh pr diff {number}` — content, not just changed filenames, since classification must distinguish a prose edit to `SKILL.md` from a step-logic edit to the same file.
+- **Review-required**: any functional code change, or any `SKILL.md`/`REFERENCE.md` step-logic edit (commands, decisioning, GraphQL mutations, branching).
+- **Exempt**: prose-only documentation, no-logic config, or formatting/whitespace/comment-only diffs. A diff is exempt overall only if every changed file is exempt.
+- **Not required** → skip straight to Step 8 (report PR ready). No poll, no `review_round` set.
+- **Required** → trigger via the same mechanism Step 6 already uses (`gh pr edit {number} --add-reviewer '@copilot'`, PowerShell quoting caveat and GraphQL fallback documented in `REFERENCE.md`'s existing Step 6 section — reused, not duplicated), set `review_round = 1`, continue to Step 3.
+- Remove `review_round = 1` from Step 1 and Step 2's text (currently set unconditionally there) — it is now set only in Step 2b, only when a trigger fires.
+- Remove Step 2's now-false line: "The first Copilot review triggers automatically."
+- Update the "Loop at a glance" ASCII diagram to show the new Step 2b branch (required → Step 3; not required → Step 8).
+- Add a short section to `REFERENCE.md` documenting the `gh pr diff` command and the review-required/exempt classification, cross-referenced from Step 2b.
+- Step 6's existing re-trigger logic (`review_round >= 2` → skip; otherwise increment and re-trigger) is unchanged — the new decisioning only gates the initial trigger, not round 2.
+- Domain docs already updated (not part of this implementation pass): `.agent-docs/context.md` has a "Review-required diff" term; `.agent-docs/adr/0004-explicit-copilot-trigger-gated-by-review-required-diff.md` records why unconditional triggering and extension-based classification were rejected.
+
+## Testing Decisions
+
+- No automated test suite exists for these skills — they are markdown instructions, not executable code.
+- Verification is a dry-run trace of Step 2b's decisioning against representative example diffs: a pure `.agent-docs/`-only PR (exempt), a `SKILL.md` step-logic PR (required), and a mixed PR touching both (required, since not every file is exempt).
+- A `code-review` skill pass over the change itself before merge, consistent with how other changes to this skill (e.g. `step4b-explicit-skip-guard`, `address-copilot-clean-review-exit`) were verified.
+
+## Out of Scope
+
+- Changes to Step 6's round-2 re-trigger logic.
+- Changes to Step 3–7's poll/fix/push-back/commit mechanics.
+- A live end-to-end test PR run through the actual loop.
+- Any change to how `code-review` or `implement` invoke `address-copilot-comments` — the external contract (push branch, create PR if needed, run the loop until clean, report PR ready) is unchanged.
+
+## Further Notes
+
+This spec's domain-doc changes (`context.md` term, ADR 0004) were already written during the `/design` session earlier in this conversation, before `/implement`'s worktree was created, then ported into this worktree since it branched fresh from `origin/main`.

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -4,6 +4,40 @@ Full command detail for each step. Replace `{owner}`, `{repo}`, `{number}`, `{id
 
 ---
 
+## Step 2b — Decide whether Copilot review is required
+
+### Fetch the diff
+
+```bash
+gh pr diff {number}
+```
+
+Reads the full diff content of every changed file, in one call — the classification below depends on what changed inside each file, not the file's extension.
+
+### Classification rule
+
+A diff is **review-required** if any changed file contains either of these:
+
+- A functional code change — new or modified logic, control flow, or scripts.
+- A step-logic edit to `SKILL.md` or `REFERENCE.md` — a new or changed bash/GraphQL command, a decisioning rule, a branching condition, or a mutation. Skill files in this repo are markdown, but their step logic is the executable behavior the harness runs — extension alone does not make them documentation.
+
+A diff is **exempt** only if every changed file is one of these:
+
+- Prose-only documentation — wording, explanation, or narrative changes that don't alter what a step does (e.g. `.agent-docs/context.md`, `README.md`, a clarifying sentence added to a skill file's prose without touching its commands or branching).
+- No-logic config — value or formatting changes to config files (`*.json`, `*.yaml`, `*.toml`) that don't add or change a script.
+- Formatting-only — whitespace, comment wording, or markdown formatting with no semantic change.
+
+**Worked examples:**
+
+| Diff | Classification |
+|---|---|
+| Only `.agent-docs/specs/*.md` and `.agent-docs/issues/*.md` changed | Exempt |
+| `SKILL.md` changed, but only a step's prose explanation was reworded | Exempt |
+| `SKILL.md` changed: a new `gh api` command added to a step | Review-required |
+| One `.agent-docs/` file and one `*.py` script changed | Review-required (not every file is exempt) |
+
+---
+
 ## Step 3 — Poll for Copilot review threads and suppressed comments
 
 Get `{owner}/{repo}` from:
@@ -234,6 +268,7 @@ gh api repos/{owner}/{repo}/pulls/{number} --jq '.node_id'
 
 The loop is complete when **any** of these conditions is met:
 
+0. **Exempt at Step 2b** — the PR's diff is docs-only, config-only, or trivial. No review requested, no poll, no `review_round` set. PR is ready to merge.
 1. **All push-backs in a round** — no code changes were made. Threads are already resolved after Step 4c, and any suppressed comments are already acknowledged via the PR-level comment posted in Step 4d. Skip Steps 5–7; do not re-trigger Copilot. PR is ready to merge.
 2. **Max reviews reached** — `review_round >= 2` at Step 6. Do not re-trigger. PR is ready to merge.
 3. **Clean review or poll exhausted** — the Step 3 poll (or Step 7 re-poll) ends with zero unresolved threads and zero suppressed comments. Either a new Copilot review was detected with no comments (exits immediately to Step 8), or 10 attempts elapsed with no new review (falls through to Step 8).

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -267,9 +267,10 @@ gh api repos/{owner}/{repo}/pulls/{number} --jq '.node_id'
 
 ## Loop termination conditions
 
-The loop is complete when **any** of these conditions is met:
+The loop (Steps 3–7) never starts at all if Step 2b judges the diff exempt — docs-only, config-only, or trivial. No review requested, no poll, no `review_round` set. PR is ready to merge.
 
-0. **Exempt at Step 2b** — the PR's diff is docs-only, config-only, or trivial. No review requested, no poll, no `review_round` set. PR is ready to merge.
+Otherwise, the loop is complete when **any** of these conditions is met:
+
 1. **All push-backs in a round** — no code changes were made. Threads are already resolved after Step 4c, and any suppressed comments are already acknowledged via the PR-level comment posted in Step 4d. Skip Steps 5–7; do not re-trigger Copilot. PR is ready to merge.
 2. **Max reviews reached** — `review_round >= 2` at Step 6. Do not re-trigger. PR is ready to merge.
 3. **Clean review or poll exhausted** — the Step 3 poll (or Step 7 re-poll) ends with zero unresolved threads and zero suppressed comments. Either a new Copilot review was detected with no comments (exits immediately to Step 8), or 10 attempts elapsed with no new review (falls through to Step 8).

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -35,6 +35,7 @@ A diff is **exempt** only if every changed file is one of these:
 | `SKILL.md` changed, but only a step's prose explanation was reworded | Exempt |
 | `SKILL.md` changed: a new `gh api` command added to a step | Review-required |
 | One `.agent-docs/` file and one `*.py` script changed | Review-required (not every file is exempt) |
+| Diff is empty (no files changed, or rename/binary-only with no content diff) | Exempt — vacuously true that every changed file is exempt |
 
 ---
 

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -19,7 +19,7 @@ Reads the full diff content of every changed file, in one call — the classific
 A diff is **review-required** if any changed file contains either of these:
 
 - A functional code change — new or modified logic, control flow, or scripts.
-- A step-logic edit to `SKILL.md` or `REFERENCE.md` — a new or changed bash/GraphQL command, a decisioning rule, a branching condition, or a mutation. Skill files in this repo are markdown, but their step logic is the executable behavior the harness runs — extension alone does not make them documentation.
+- A step-logic edit to `SKILL.md`, `REFERENCE.md`, or `WORKFLOW.md` — a new or changed bash/GraphQL command, a decisioning rule, a branching condition, or a mutation. Skill files in this repo are markdown, but their step logic is the executable behavior the harness runs — extension alone does not make them documentation.
 
 A diff is **exempt** only if every changed file is one of these:
 
@@ -27,7 +27,7 @@ A diff is **exempt** only if every changed file is one of these:
 - No-logic config — value or formatting changes to config files (`*.json`, `*.yaml`, `*.toml`) that don't add or change a script.
 - Formatting-only — whitespace, comment wording, or markdown formatting with no semantic change.
 
-**Worked examples:**
+### Worked examples
 
 | Diff | Classification |
 |---|---|

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -13,8 +13,11 @@ Runs a loop: fetch Copilot comments → fix or push back → commit → push →
 
 ```text
 Step 0  gh available?
-Step 1  PR exists? ──No──► Step 2: create PR (review_round = 1)
-        PR exists? ──Yes──► review_round = 1
+Step 1  PR exists? ──No──► Step 2: create PR ──► Step 2b
+        PR exists? ──Yes──► Step 2b
+Step 2b Read PR diff (`gh pr diff`); review-required?
+        No (exempt: docs/config/trivial only) ──► Step 8 (no trigger, no poll)
+        Yes (functional code or skill step-logic) ──► trigger Copilot; review_round = 1 ──► Step 3
 Step 3  Record baseline Copilot review ID; poll every 60s:
         thread count > 0? ─────────────────────────────────────────► Step 4
         suppressed comments > 0 in latest review body? ─────────────► Step 4
@@ -49,7 +52,7 @@ Then `gh auth login`. Do not proceed until `gh --version` passes.
 gh pr list --head $(git branch --show-current) --json number,title,url
 ```
 
-PR found → note the number. Set `review_round = 1`. Skip to Step 3.
+PR found → note the number. Continue to Step 2b.
 No PR → go to Step 2.
 
 ## Step 2 — Create the PR
@@ -59,7 +62,22 @@ BASE=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')
 gh pr create --base "$BASE" --title "<title>" --body "<summary and test plan>"
 ```
 
-Note the PR number. Set `review_round = 1`. The first Copilot review triggers automatically.
+Note the PR number. Continue to Step 2b.
+
+## Step 2b — Decide whether Copilot review is required
+
+GitHub no longer auto-triggers a Copilot review on PR creation, so this step decides whether the PR needs one and, if so, requests it explicitly.
+
+Fetch the full diff content — not just changed filenames, since the decision depends on what changed, not the file extension (a prose edit and a step-logic edit to the same `SKILL.md` file must be classified differently):
+
+```bash
+gh pr diff {number}
+```
+
+See the Decide Whether Copilot Review Is Required section in [REFERENCE.md](REFERENCE.md) for the classification rule and worked examples.
+
+**Review-required** → trigger via the same command Step 6 uses (see the Re-trigger Copilot Review section in [REFERENCE.md](REFERENCE.md)); set `review_round = 1`; continue to Step 3.
+**Exempt** → skip straight to Step 8. Do not trigger, do not set `review_round`, do not poll.
 
 ## Step 3 — Poll for Copilot review threads and suppressed comments
 


### PR DESCRIPTION
## Summary

GitHub no longer auto-triggers a Copilot review on PR creation, so `address-copilot-comments` Step 2's "the first Copilot review triggers automatically" assumption is now false. This adds a new Step 2b that decides — from the PR's diff *content*, not file extension — whether the PR needs an initial Copilot review, and explicitly requests one when it does.

Closes #42

## Test plan

- [x] Dry-run traced Step 2b against 4 scenarios: docs-only diff (exempt), SKILL.md/REFERENCE.md step-logic edit (review-required), mixed diff (review-required), round-2 re-trigger (unaffected).
- [x] 5 review passes (2 consecutive clean) via `/code-review`'s Standards + Spec agents.
- [x] Pre-commit clean on every commit (changed-files + full-repo passes).

🤖 Generated with Claude Code