### PR TITLE
Document gh api --jq / jq --arg pitfall

### DIFF
--- a/.agent-docs/issues/chore/gh-jq-arg-pitfall-doc.md
+++ b/.agent-docs/issues/chore/gh-jq-arg-pitfall-doc.md
@@ -13,7 +13,7 @@
 Add a "Common pitfalls" section near the top of `address-copilot-comments/REFERENCE.md`,
 before Step 2b, stating that `gh api --jq` does not accept jq's own `--arg` flag. Show a
 "doesn't work" vs "works" pair of snippets, where the "works" side inlines the shell value
-directly into the query string — the pattern every other snippet in the file already uses.
+directly into the query string.
 
 ### Acceptance criteria
 

--- a/.agent-docs/issues/chore/gh-jq-arg-pitfall-doc.md
+++ b/.agent-docs/issues/chore/gh-jq-arg-pitfall-doc.md
@@ -1,5 +1,7 @@
 # Issues: chore/gh-jq-arg-pitfall-doc
 
+> Work complete — PR ready to merge.
+
 ## Document the gh api --jq / jq --arg pitfall
 
 **GitHub**: #44
@@ -17,12 +19,12 @@ directly into the query string.
 
 ### Acceptance criteria
 
-- [ ] `address-copilot-comments/REFERENCE.md` has a "Common pitfalls" section placed before
+- [x] `address-copilot-comments/REFERENCE.md` has a "Common pitfalls" section placed before
       Step 2b.
-- [ ] The section states plainly that `gh`'s `--jq` flag does not accept jq's `--arg` flag.
-- [ ] The section shows both a non-working `--jq --arg ...` example and the correct
+- [x] The section states plainly that `gh`'s `--jq` flag does not accept jq's `--arg` flag.
+- [x] The section shows both a non-working `--jq --arg ...` example and the correct
       inline-substitution alternative.
-- [ ] No existing snippet's behavior or wording elsewhere in the file changes.
-- [ ] `pre-commit-check` passes on the file.
+- [x] No existing snippet's behavior or wording elsewhere in the file changes.
+- [x] `pre-commit-check` passes on the file.
 
 ---

--- a/.agent-docs/issues/chore/gh-jq-arg-pitfall-doc.md
+++ b/.agent-docs/issues/chore/gh-jq-arg-pitfall-doc.md
@@ -2,7 +2,7 @@
 
 ## Document the gh api --jq / jq --arg pitfall
 
-**Issue**: #44
+**GitHub**: #44
 
 **Blocked by**: None
 

--- a/.agent-docs/issues/chore/gh-jq-arg-pitfall-doc.md
+++ b/.agent-docs/issues/chore/gh-jq-arg-pitfall-doc.md
@@ -1,0 +1,28 @@
+# Issues: chore/gh-jq-arg-pitfall-doc
+
+## Document the gh api --jq / jq --arg pitfall
+
+**Issue**: #44
+
+**Blocked by**: None
+
+**User stories**: 1, 2
+
+### What to build
+
+Add a "Common pitfalls" section near the top of `address-copilot-comments/REFERENCE.md`,
+before Step 2b, stating that `gh api --jq` does not accept jq's own `--arg` flag. Show a
+"doesn't work" vs "works" pair of snippets, where the "works" side inlines the shell value
+directly into the query string — the pattern every other snippet in the file already uses.
+
+### Acceptance criteria
+
+- [ ] `address-copilot-comments/REFERENCE.md` has a "Common pitfalls" section placed before
+      Step 2b.
+- [ ] The section states plainly that `gh`'s `--jq` flag does not accept jq's `--arg` flag.
+- [ ] The section shows both a non-working `--jq --arg ...` example and the correct
+      inline-substitution alternative.
+- [ ] No existing snippet's behavior or wording elsewhere in the file changes.
+- [ ] `pre-commit-check` passes on the file.
+
+---

--- a/.agent-docs/specs/chore/gh-jq-arg-pitfall-doc.md
+++ b/.agent-docs/specs/chore/gh-jq-arg-pitfall-doc.md
@@ -13,9 +13,8 @@ query string instead.
 ## Solution
 
 Add a single, canonical "Common pitfalls" note near the top of `REFERENCE.md` that states the
-limitation plainly and shows the correct pattern already used throughout the rest of the
-document: inline the shell variable directly into the query string rather than passing
-`--arg` through `--jq`.
+limitation plainly and shows the correct fix: inline the shell variable directly into the
+query string rather than passing `--arg` through `--jq`.
 
 ## User Stories
 
@@ -35,9 +34,10 @@ document: inline the shell variable directly into the query string rather than p
   follow.
 - Content: state that `gh`'s `--jq` does not accept jq's `--arg` flag (the two are unrelated
   flags despite the shared name), show a short "doesn't work" vs "works" pair of snippets —
-  the "works" side being the inline-substitution pattern (e.g. `--jq '... "{value}" ...'`
-  with the shell variable interpolated directly into the query string), matching the pattern
-  every existing snippet in the file already uses.
+  the "works" side interpolating the shell variable directly into the double-quoted filter
+  string (the only mechanism that both expands the shell variable and stays a single `--jq`
+  argument; existing snippets elsewhere in the file don't face this problem since none of
+  them interpolate a shell variable into a filter).
 - No changes to any existing bash/GraphQL snippet's behavior — this is additive documentation
   only.
 

--- a/.agent-docs/specs/chore/gh-jq-arg-pitfall-doc.md
+++ b/.agent-docs/specs/chore/gh-jq-arg-pitfall-doc.md
@@ -1,0 +1,61 @@
+# Document the `gh api --jq` / jq `--arg` Pitfall
+
+## Problem Statement
+
+`address-copilot-comments/REFERENCE.md` uses `gh api ... --jq '...'` extensively, but nothing
+in the doc warns that `gh`'s `--jq` flag does not accept jq's own `--arg` flag. A user who
+tries `gh api ... --jq --arg foo "$bar" '...'` gets a confusing `gh` argument-count error
+(`accepts 1 arg(s), received 4`) rather than a clear explanation, and can burn many failed
+attempts polling before noticing the real bug — as happened in a recent PR, where this cost
+10 failed poll attempts before it was diagnosed and fixed by inlining the value into the
+query string instead.
+
+## Solution
+
+Add a single, canonical "Common pitfalls" note near the top of `REFERENCE.md` that states the
+limitation plainly and shows the correct pattern already used throughout the rest of the
+document: inline the shell variable directly into the query string rather than passing
+`--arg` through `--jq`.
+
+## User Stories
+
+1. As an agent following `address-copilot-comments`, I want REFERENCE.md to warn me up front
+   that `gh api --jq` cannot take jq's `--arg` flag, so that I use the correct
+   inline-substitution pattern the first time instead of rediscovering the failure through
+   trial and error.
+2. As an agent debugging a `gh api` command that unexpectedly errors with an argument-count
+   message, I want a documented pitfall I can match against, so that I can diagnose the cause
+   quickly instead of assuming the query itself is wrong.
+
+## Implementation Decisions
+
+- File touched: `address-copilot-comments/REFERENCE.md` only.
+- Add one "Common pitfalls" section directly after the document's title/intro line, before
+  the first step (Step 2b), so it is seen before any of the `gh api --jq` examples that
+  follow.
+- Content: state that `gh`'s `--jq` does not accept jq's `--arg` flag (the two are unrelated
+  flags despite the shared name), show a short "doesn't work" vs "works" pair of snippets —
+  the "works" side being the inline-substitution pattern (e.g. `--jq '... "{value}" ...'`
+  with the shell variable interpolated directly into the query string), matching the pattern
+  every existing snippet in the file already uses.
+- No changes to any existing bash/GraphQL snippet's behavior — this is additive documentation
+  only.
+
+## Testing Decisions
+
+- No code seam exists; this is a markdown documentation change.
+- Verification is by direct review of the rendered section for accuracy and by running the
+  `pre-commit-check` skill (markdown lint / formatting hooks) to confirm the file is
+  well-formed.
+
+## Out of Scope
+
+- Extracting the polling/suppressed-comment jq logic into a bundled script (a separate,
+  lower-priority follow-up).
+- Any other pitfalls beyond the `--jq`/`--arg` one (future pitfalls can be appended to the
+  same section later).
+
+## Further Notes
+
+This is the first of six small fixes queued from a retrospective on a recent PR; each is
+being run through its own `/implement` loop rather than bundled together.

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -7,18 +7,19 @@ Full command detail for each step. Replace `{owner}`, `{repo}`, `{number}`, `{id
 ## Common pitfalls
 
 **`gh api --jq` does not accept jq's `--arg` flag.** They share a name but are unrelated —
-`gh`'s `--jq` flag takes a single jq filter string, not a place to pass jq's own CLI flags.
-Combining them fails with a confusing `gh` argument-count error, not a jq error:
+`--jq` consumes exactly one token as its filter value. Writing `--arg foo "$bar" '<filter>'`
+after it means `gh` takes `--arg` itself as that filter value, and `foo`, `"$bar"`, and the
+real filter all become extra positional arguments to `gh api`, which only accepts one (the
+API path) — so the failure is a `gh api` argument-count error, not a jq error:
 
 ```bash
-# Doesn't work — `gh` parses `--arg`, "foo", "$bar", and the filter as four separate
-# positional arguments to --jq, not as jq's --arg syntax:
+# Doesn't work — "--arg" becomes --jq's filter value; foo, "$bar", and the real filter
+# are then three extra positional args to `gh api`, which only accepts one:
 gh api "repos/{owner}/{repo}/pulls/{number}/reviews" \
   --jq --arg foo "$bar" '.[] | select(.user.login == $foo)'
-# → unknown command "..." for "gh api"  /  accepts 1 arg(s), received 4
+# fails with: accepts 1 arg(s), received 4
 
-# Works — inline the shell value directly into the query string instead,
-# the pattern every snippet below this line uses:
+# Works — interpolate the shell value directly into the filter string instead:
 gh api "repos/{owner}/{repo}/pulls/{number}/reviews" \
   --jq ".[] | select(.user.login == \"$bar\")"
 ```

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -4,6 +4,27 @@ Full command detail for each step. Replace `{owner}`, `{repo}`, `{number}`, `{id
 
 ---
 
+## Common pitfalls
+
+**`gh api --jq` does not accept jq's `--arg` flag.** They share a name but are unrelated —
+`gh`'s `--jq` flag takes a single jq filter string, not a place to pass jq's own CLI flags.
+Combining them fails with a confusing `gh` argument-count error, not a jq error:
+
+```bash
+# Doesn't work — `gh` parses `--arg`, "foo", "$bar", and the filter as four separate
+# positional arguments to --jq, not as jq's --arg syntax:
+gh api "repos/{owner}/{repo}/pulls/{number}/reviews" \
+  --jq --arg foo "$bar" '.[] | select(.user.login == $foo)'
+# → unknown command "..." for "gh api"  /  accepts 1 arg(s), received 4
+
+# Works — inline the shell value directly into the query string instead,
+# the pattern every snippet below this line uses:
+gh api "repos/{owner}/{repo}/pulls/{number}/reviews" \
+  --jq ".[] | select(.user.login == \"$bar\")"
+```
+
+---
+
 ## Step 2b — Decide whether Copilot review is required
 
 ### Fetch the diff


### PR DESCRIPTION
## Summary

`address-copilot-comments/REFERENCE.md` uses `gh api ... --jq '...'` extensively, but nothing warned that `gh`'s `--jq` flag doesn't accept jq's own `--arg` flag. Combining them fails with a confusing `gh api` argument-count error, not a jq error - this cost 10 failed poll attempts in a real PR before the real bug was diagnosed.

Adds a "Common pitfalls" section near the top of REFERENCE.md, before Step 2b, explaining the mechanism and showing the correct inline-substitution fix.

Closes #44.

## Test plan

- [x] pre-commit-check passes on all changed files (both changed-files and full-repo passes).
- [x] Verified the "doesn't work" example against installed gh (v2.95.0) - reproduces "accepts 1 arg(s), received 4".
- [x] Verified the "works" example against installed gh - passes argument parsing (fails only on 404 for the placeholder repo, as expected).
- [x] Two consecutive code-review passes (Standards + Spec axes) with zero findings.