### PR TITLE
Extract Copilot review poll logic into a bundled script

### DIFF
--- a/.agent-docs/issues/chore/copilot-poll-helper-script.md
+++ b/.agent-docs/issues/chore/copilot-poll-helper-script.md
@@ -1,0 +1,33 @@
+# Issues: chore/copilot-poll-helper-script
+
+## Extract Copilot review poll logic into a bundled script
+
+**GitHub**: #46
+
+**Blocked by**: None
+
+**User stories**: 1, 2
+
+### What to build
+
+Add `address-copilot-comments/scripts/check-review-status.sh`, taking
+`<owner> <repo> <pr_number> [baseline_review_id]` and printing `THREAD_COUNT`,
+`SUPPRESSED_COUNT`, `CURRENT_REVIEW_ID`, and `DECISION` (`ACTIONABLE`/`CLEAN`/`PENDING`).
+Update `REFERENCE.md`'s Step 3 (baseline capture + poll loop) to call this script instead of
+the inline bash blocks it currently repeats, and update Step 4's suppressed-comment section
+to re-fetch the review body directly (it can no longer reuse a `$REVIEW_BODY` variable set by
+Step 3's own inline bash, since that logic now lives in a separate script process).
+
+### Acceptance criteria
+
+- [ ] `address-copilot-comments/scripts/check-review-status.sh` exists, is invoked via
+      `bash <path>`, and outputs the four documented `KEY=value` lines.
+- [ ] The script correctly reports `ACTIONABLE`, `CLEAN`, and `PENDING` against real `gh api`
+      data (verified manually against a real PR).
+- [ ] `REFERENCE.md`'s Step 3 baseline capture and poll loop call the script instead of
+      repeating the inline `gh api`/GraphQL/jq blocks.
+- [ ] `REFERENCE.md`'s Step 4 suppressed-comments section fetches the review body itself
+      rather than referencing a `$REVIEW_BODY` variable from Step 3.
+- [ ] `pre-commit-check` passes on all changed files.
+
+---

--- a/.agent-docs/issues/chore/copilot-poll-helper-script.md
+++ b/.agent-docs/issues/chore/copilot-poll-helper-script.md
@@ -1,5 +1,7 @@
 # Issues: chore/copilot-poll-helper-script
 
+> Work complete — PR ready to merge.
+
 ## Extract Copilot review poll logic into a bundled script
 
 **GitHub**: #46
@@ -20,18 +22,18 @@ Step 3's own inline bash, since that logic now lives in a separate script proces
 
 ### Acceptance criteria
 
-- [ ] `address-copilot-comments/scripts/check-review-status.sh` exists, is invoked via
+- [x] `address-copilot-comments/scripts/check-review-status.sh` exists, is invoked via
       `bash <path>`, and outputs the four documented `KEY=value` lines.
-- [ ] The script correctly reports `ACTIONABLE`, `CLEAN`, `PENDING`, and `ERROR` against real
+- [x] The script correctly reports `ACTIONABLE`, `CLEAN`, `PENDING`, and `ERROR` against real
       `gh api` data (verified manually against a real PR), including that a 3-argument
       (no-baseline) call never reports `CLEAN` even when a prior review already exists.
-- [ ] Owner/repo/pr_number are validated against GitHub's identifier charset and passed as
+- [x] Owner/repo/pr_number are validated against GitHub's identifier charset and passed as
       bound GraphQL variables (not string-concatenated into the query), and a malformed
       invocation exits 2 with a usage message rather than crashing under `set -u`.
-- [ ] `REFERENCE.md`'s Step 3 baseline capture and poll loop call the script instead of
+- [x] `REFERENCE.md`'s Step 3 baseline capture and poll loop call the script instead of
       repeating the inline `gh api`/GraphQL/jq blocks.
-- [ ] `REFERENCE.md`'s Step 4 suppressed-comments section fetches the review body itself
+- [x] `REFERENCE.md`'s Step 4 suppressed-comments section fetches the review body itself
       rather than referencing a `$REVIEW_BODY` variable from Step 3.
-- [ ] `pre-commit-check` passes on all changed files.
+- [x] `pre-commit-check` passes on all changed files.
 
 ---

--- a/.agent-docs/issues/chore/copilot-poll-helper-script.md
+++ b/.agent-docs/issues/chore/copilot-poll-helper-script.md
@@ -22,8 +22,12 @@ Step 3's own inline bash, since that logic now lives in a separate script proces
 
 - [ ] `address-copilot-comments/scripts/check-review-status.sh` exists, is invoked via
       `bash <path>`, and outputs the four documented `KEY=value` lines.
-- [ ] The script correctly reports `ACTIONABLE`, `CLEAN`, and `PENDING` against real `gh api`
-      data (verified manually against a real PR).
+- [ ] The script correctly reports `ACTIONABLE`, `CLEAN`, `PENDING`, and `ERROR` against real
+      `gh api` data (verified manually against a real PR), including that a 3-argument
+      (no-baseline) call never reports `CLEAN` even when a prior review already exists.
+- [ ] Owner/repo/pr_number are validated against GitHub's identifier charset and passed as
+      bound GraphQL variables (not string-concatenated into the query), and a malformed
+      invocation exits 2 with a usage message rather than crashing under `set -u`.
 - [ ] `REFERENCE.md`'s Step 3 baseline capture and poll loop call the script instead of
       repeating the inline `gh api`/GraphQL/jq blocks.
 - [ ] `REFERENCE.md`'s Step 4 suppressed-comments section fetches the review body itself

--- a/.agent-docs/specs/chore/copilot-poll-helper-script.md
+++ b/.agent-docs/specs/chore/copilot-poll-helper-script.md
@@ -71,11 +71,15 @@ spell out identically, reporting it as a single `DECISION` value.
   auto-detects type): an all-digit owner or repo name is a legitimate GitHub identifier, and
   `-F` would otherwise send it as a JSON number, which the `String!`-typed query variables
   reject. `-F` is still used for `number`, which must bind to the `Int!` variable.
-- The two identical-endpoint calls for `.body` and `.id` stay separate rather than merging
-  into one `--jq` call with a delimited (e.g. `@tsv`) output: a review body is arbitrary
-  multi-line markdown, and safely combining it with the id in one line would need base64-style
-  encoding — whose decode flag differs between GNU (`base64 -d`) and BSD/macOS (`base64 -D`)
-  coreutils. The extra request is the accepted trade-off over that portability split.
+- `.id` and `.body` are fetched in a single call via `--jq`'s comma operator
+  (`(.id // empty), (.body // empty)`), not two separate requests: `gh api --jq` prints one
+  raw-text result per line, the id is always single-line (a bare number or empty), so it
+  always lands on line 1, and the (possibly multi-line) body is unambiguously everything from
+  line 2 onward (`head -1` / `tail -n +2`) — no delimiter or encoding required. An earlier
+  version of this script issued two identical requests and justified it with a since-disproven
+  claim that combining them would require base64 encoding; that rationale was wrong on both
+  counts (a plain line-1/rest-of-lines split works, and even an encoding-based approach
+  wouldn't have needed a full round-trip duplication).
 
 ## Testing Decisions
 
@@ -92,6 +96,9 @@ spell out identically, reporting it as a single `DECISION` value.
   Also verified the usage-error path (wrong argument count, and an owner containing `"`)
   exits 2 with a message on stderr rather than crashing under `set -u`, and the `ERROR` path
   (a nonexistent PR number) reports `DECISION=ERROR` rather than `PENDING`.
+- Re-verified all of the above after merging the `.id`/`.body` fetch into one call: `PENDING`
+  (3-arg), `CLEAN` (4-arg, baseline `0`), `PENDING` (4-arg, baseline matches current),
+  `DECISION=ERROR` (nonexistent PR), and the usage-error exit — all unchanged against #45.
 
 ## Out of Scope
 

--- a/.agent-docs/specs/chore/copilot-poll-helper-script.md
+++ b/.agent-docs/specs/chore/copilot-poll-helper-script.md
@@ -1,0 +1,75 @@
+# Extract Copilot Review Poll Logic Into a Bundled Script
+
+## Problem Statement
+
+`address-copilot-comments/REFERENCE.md`'s poll logic — baseline review-ID capture, an
+unresolved-thread GraphQL query, a suppressed-comment body fetch plus regex count, and a
+current-review-ID re-fetch — is written out as inline bash blocks twice: once for Step 3's
+initial poll loop and again (by reference, "poll as in Step 3") for Step 7's re-poll after a
+re-triggered review. Because it's markdown prose rather than a single source of truth, the
+same class of subtle `gh`/jq bug that already cost 10 failed poll attempts in a real PR (see
+the `chore/gh-jq-arg-pitfall-doc` fix) has two places it could be introduced or drift between.
+
+## Solution
+
+Extract the three checks (thread count, suppressed-comment count, review-ID-changed) into one
+bundled script, `address-copilot-comments/scripts/check-review-status.sh`, that both Step 3
+and Step 7 call. The script also centralizes the branching decision the two steps currently
+spell out identically, reporting it as a single `DECISION` value.
+
+## User Stories
+
+1. As an agent following `address-copilot-comments`, I want the poll check to live in one
+   script instead of duplicated bash blocks, so that a bug in the check logic only needs
+   fixing in one place.
+2. As an agent running Step 3 or Step 7, I want a single command that tells me whether to
+   proceed to Step 4, Step 8, or wait and retry, so that I don't have to re-derive the
+   three-way branching from prose each time.
+
+## Implementation Decisions
+
+- New file: `address-copilot-comments/scripts/check-review-status.sh`.
+- Interface: `check-review-status.sh <owner> <repo> <pr_number> [baseline_review_id]`,
+  invoked as `bash "<skill-base-dir>/scripts/check-review-status.sh" ...` — always via `bash
+  <path>`, never relying on the shebang/execute bit, since skill files sync across OSes and
+  the execute bit isn't guaranteed to survive that sync.
+- `<skill-base-dir>` is the path already shown as "Base directory for this skill" when
+  `address-copilot-comments` is invoked — not the caller's working directory, which is the
+  target repo being worked on, not the skills repo.
+- Output: four `KEY=value` lines on stdout — `THREAD_COUNT`, `SUPPRESSED_COUNT`,
+  `CURRENT_REVIEW_ID`, and a computed `DECISION` (`ACTIONABLE` | `CLEAN` | `PENDING`). Always
+  exits 0; callers branch on the `DECISION` line, not the exit code.
+- The one-time "capture baseline before polling" step becomes a single no-baseline call to
+  the same script, using its `CURRENT_REVIEW_ID` output as the baseline for later calls. If
+  that first call already reports `DECISION=ACTIONABLE`, the poll loop is skipped entirely.
+- The script does not return the Copilot review body text (only the suppressed-comment
+  count) — Step 4 re-fetches the body itself when it needs to read suppressed-comment entries
+  for real, since embedding arbitrary multi-line markdown into single-line `KEY=value` output
+  is fragile to parse reliably.
+- No ADR: reverting to inline bash later is a low-cost change if this pattern doesn't pan
+  out, so it fails the "hard to reverse" bar for recording a decision.
+
+## Testing Decisions
+
+- No shell-test harness (bats, shellspec, etc.) exists in this repo, and `gh api` is the
+  script's only real dependency — building a mocking harness for one script is out of
+  proportion to the script itself.
+- Verified manually against a real PR (`mholubinka1/skills#45`, already merged) during
+  implementation: confirmed `CLEAN` (thread resolved, review ID present) and `PENDING`
+  (explicit baseline equal to current ID) outputs against live `gh api` data. `ACTIONABLE`
+  was already exercised live during that PR's own review round.
+
+## Out of Scope
+
+- A shell-testing framework for this repo generally.
+- Changing Step 4's suppressed-comment handling beyond re-fetching the review body itself
+  (previously it reused a `$REVIEW_BODY` shell variable set inline in Step 3's own bash,
+  which no longer exists once that logic moves into a separate script process).
+
+## Further Notes
+
+This is the second of six small fixes queued from a retrospective on a recent PR; each is
+being run through its own `/implement` loop rather than bundled together. Unlike fix #1
+(pure documentation), this one is scoped down from its original "nice-to-have" framing after
+confirming with the user that the motivating bug is already fixed and this is purely a
+DRY/robustness improvement.

--- a/.agent-docs/specs/chore/copilot-poll-helper-script.md
+++ b/.agent-docs/specs/chore/copilot-poll-helper-script.md
@@ -67,6 +67,12 @@ spell out identically, reporting it as a single `DECISION` value.
   is fragile to parse reliably.
 - No ADR: reverting to inline bash later is a low-cost change if this pattern doesn't pan
   out, so it fails the "hard to reverse" bar for recording a decision.
+- The thread-count GraphQL `--jq` filter coerces `.comments.nodes[0].author.login` with
+  `// ""` before calling `test(...)`: `test` errors on a `null` input (jq requires a string),
+  and `.login` resolves to `null` whenever the thread has no comments or the first comment's
+  author is unavailable (e.g. a deleted GitHub account) — without the guard, that single
+  thread would fail the whole GraphQL call and misreport a successful API response as
+  `DECISION=ERROR`.
 - `owner`/`repo` are passed to the GraphQL call via `-f` (always a string), not `-F` (which
   auto-detects type): an all-digit owner or repo name is a legitimate GitHub identifier, and
   `-F` would otherwise send it as a JSON number, which the `String!`-typed query variables

--- a/.agent-docs/specs/chore/copilot-poll-helper-script.md
+++ b/.agent-docs/specs/chore/copilot-poll-helper-script.md
@@ -67,12 +67,17 @@ spell out identically, reporting it as a single `DECISION` value.
   is fragile to parse reliably.
 - No ADR: reverting to inline bash later is a low-cost change if this pattern doesn't pan
   out, so it fails the "hard to reverse" bar for recording a decision.
-- The thread-count GraphQL `--jq` filter coerces `.comments.nodes[0].author.login` with
-  `// ""` before calling `test(...)`: `test` errors on a `null` input (jq requires a string),
-  and `.login` resolves to `null` whenever the thread has no comments or the first comment's
-  author is unavailable (e.g. a deleted GitHub account) — without the guard, that single
-  thread would fail the whole GraphQL call and misreport a successful API response as
-  `DECISION=ERROR`.
+- Every `.login | test(...)` filter — the thread-count GraphQL query's
+  `.comments.nodes[0].author.login`, the script's own `.user.login` on the merged id/body
+  fetch, and `REFERENCE.md`'s Step 4 suppressed-comments re-fetch (which uses the identical
+  query shape) — coerces with `// ""` before calling `test(...)`: `test` errors on a `null`
+  input (jq requires a string), and `.login` resolves to `null` whenever a thread has no
+  comments, or a comment's or review's author is unavailable (e.g. a deleted GitHub account).
+  Without the guard, one such thread or review fails the whole `gh api` call and misreports a
+  successful API response as `DECISION=ERROR`. REFERENCE.md's other, pre-existing occurrences
+  of this same unguarded pattern (e.g. the "Fetch all unresolved Copilot review threads" query
+  in Step 4) predate this branch and are out of scope here — untouched code, not introduced or
+  modified by this fix.
 - `owner`/`repo` are passed to the GraphQL call via `-f` (always a string), not `-F` (which
   auto-detects type): an all-digit owner or repo name is a legitimate GitHub identifier, and
   `-F` would otherwise send it as a JSON number, which the `String!`-typed query variables

--- a/.agent-docs/specs/chore/copilot-poll-helper-script.md
+++ b/.agent-docs/specs/chore/copilot-poll-helper-script.md
@@ -29,6 +29,10 @@ spell out identically, reporting it as a single `DECISION` value.
 ## Implementation Decisions
 
 - New file: `address-copilot-comments/scripts/check-review-status.sh`.
+- New file: `.gitattributes`, forcing `*.sh text eol=lf` — this repo's `core.autocrlf=true`
+  default would otherwise convert this script to CRLF on a fresh checkout, breaking its `\`
+  line continuations. This is the first shell script in the repo, so no prior file needed
+  this protection.
 - Interface: `check-review-status.sh <owner> <repo> <pr_number> [baseline_review_id]`,
   invoked as `bash "<skill-base-dir>/scripts/check-review-status.sh" ...` — always via `bash
   <path>`, never relying on the shebang/execute bit, since skill files sync across OSes and
@@ -62,6 +66,15 @@ spell out identically, reporting it as a single `DECISION` value.
   is fragile to parse reliably.
 - No ADR: reverting to inline bash later is a low-cost change if this pattern doesn't pan
   out, so it fails the "hard to reverse" bar for recording a decision.
+- `owner`/`repo` are passed to the GraphQL call via `-f` (always a string), not `-F` (which
+  auto-detects type): an all-digit owner or repo name is a legitimate GitHub identifier, and
+  `-F` would otherwise send it as a JSON number, which the `String!`-typed query variables
+  reject. `-F` is still used for `number`, which must bind to the `Int!` variable.
+- The two identical-endpoint calls for `.body` and `.id` stay separate rather than merging
+  into one `--jq` call with a delimited (e.g. `@tsv`) output: a review body is arbitrary
+  multi-line markdown, and safely combining it with the id in one line would need base64-style
+  encoding — whose decode flag differs between GNU (`base64 -d`) and BSD/macOS (`base64 -D`)
+  coreutils. The extra request is the accepted trade-off over that portability split.
 
 ## Testing Decisions
 

--- a/.agent-docs/specs/chore/copilot-poll-helper-script.md
+++ b/.agent-docs/specs/chore/copilot-poll-helper-script.md
@@ -59,7 +59,8 @@ spell out identically, reporting it as a single `DECISION` value.
   reports `DECISION=ACTIONABLE`, the poll loop is skipped entirely.
 - Owner/repo/PR-number flow into a GraphQL query and a REST path; the script validates them
   against GitHub's own identifier charset before use, and the GraphQL query passes them as
-  bound `-F` variables (not string-concatenated into the query text) to avoid injection.
+  bound variables (not string-concatenated into the query text) to avoid injection — see the
+  `-f`/`-F` split described below for which flag each variable uses and why.
 - The script does not return the Copilot review body text (only the suppressed-comment
   count) — Step 4 re-fetches the body itself when it needs to read suppressed-comment entries
   for real, since embedding arbitrary multi-line markdown into single-line `KEY=value` output

--- a/.agent-docs/specs/chore/copilot-poll-helper-script.md
+++ b/.agent-docs/specs/chore/copilot-poll-helper-script.md
@@ -37,11 +37,25 @@ spell out identically, reporting it as a single `DECISION` value.
   `address-copilot-comments` is invoked — not the caller's working directory, which is the
   target repo being worked on, not the skills repo.
 - Output: four `KEY=value` lines on stdout — `THREAD_COUNT`, `SUPPRESSED_COUNT`,
-  `CURRENT_REVIEW_ID`, and a computed `DECISION` (`ACTIONABLE` | `CLEAN` | `PENDING`). Always
-  exits 0; callers branch on the `DECISION` line, not the exit code.
-- The one-time "capture baseline before polling" step becomes a single no-baseline call to
-  the same script, using its `CURRENT_REVIEW_ID` output as the baseline for later calls. If
-  that first call already reports `DECISION=ACTIONABLE`, the poll loop is skipped entirely.
+  `CURRENT_REVIEW_ID`, and a computed `DECISION` (`ACTIONABLE` | `CLEAN` | `PENDING` |
+  `ERROR`). Exits 0 for any well-formed call, including `ERROR` — callers branch on the
+  `DECISION` line, not the exit code. Exits 2 with a usage message on stderr for a malformed
+  invocation (wrong argument count, or an owner/repo/pr_number that fails a GitHub-identifier
+  charset check).
+- `DECISION=ERROR` covers a `gh api` call itself failing (network, auth, not-found) — this is
+  reported distinctly rather than folded into `PENDING`, so a real failure doesn't get treated
+  as "nothing to do yet, keep polling."
+- The one-time "capture baseline before polling" step becomes a single no-baseline (3-argument)
+  call to the same script, using its `CURRENT_REVIEW_ID` output as the baseline for later
+  calls. Whether a baseline was supplied is tracked via argument count (`$#`), not by treating
+  an empty 4th argument as "no baseline" — those are different cases: a 3-argument call means
+  "nothing to compare against yet" and must never report `CLEAN`, while a genuine empty-string
+  baseline (a 4-argument call where the captured baseline was itself empty, meaning no prior
+  review existed) is a real basis for comparison. If the first (3-argument) call already
+  reports `DECISION=ACTIONABLE`, the poll loop is skipped entirely.
+- Owner/repo/PR-number flow into a GraphQL query and a REST path; the script validates them
+  against GitHub's own identifier charset before use, and the GraphQL query passes them as
+  bound `-F` variables (not string-concatenated into the query text) to avoid injection.
 - The script does not return the Copilot review body text (only the suppressed-comment
   count) — Step 4 re-fetches the body itself when it needs to read suppressed-comment entries
   for real, since embedding arbitrary multi-line markdown into single-line `KEY=value` output
@@ -58,6 +72,12 @@ spell out identically, reporting it as a single `DECISION` value.
   implementation: confirmed `CLEAN` (thread resolved, review ID present) and `PENDING`
   (explicit baseline equal to current ID) outputs against live `gh api` data. `ACTIONABLE`
   was already exercised live during that PR's own review round.
+- Additionally verified, after a code-review round found the 3-argument call could
+  incorrectly report `CLEAN` against a PR with a pre-existing review: a 3-argument call
+  against #45 now reports `PENDING` (not `CLEAN`) despite a non-empty `CURRENT_REVIEW_ID`.
+  Also verified the usage-error path (wrong argument count, and an owner containing `"`)
+  exits 2 with a message on stderr rather than crashing under `set -u`, and the `ERROR` path
+  (a nonexistent PR number) reports `DECISION=ERROR` rather than `PENDING`.
 
 ## Out of Scope
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -85,17 +85,18 @@ bash "<skill-base-dir>/scripts/check-review-status.sh" {owner} {repo} {number} [
 It prints four lines:
 
 ```text
-THREAD_COUNT=<n>
-SUPPRESSED_COUNT=<n>
+THREAD_COUNT=<n>          (always numeric, including 0 on ERROR)
+SUPPRESSED_COUNT=<n>      (always numeric, including 0 on ERROR)
 CURRENT_REVIEW_ID=<id or empty>
 DECISION=ACTIONABLE|CLEAN|PENDING|ERROR
 ```
 
 - **`ACTIONABLE`** — `THREAD_COUNT` or `SUPPRESSED_COUNT` is non-zero. Exit the poll loop and
   go to Step 4.
-- **`CLEAN`** — only possible when a `baseline_review_id` argument was supplied: it is
-  non-empty and `CURRENT_REVIEW_ID` differs from it, with nothing actionable. Copilot has
-  reviewed and left nothing to address — go to Step 8 immediately.
+- **`CLEAN`** — only possible when a `baseline_review_id` argument was supplied at all (even
+  if that argument was itself an empty string, meaning no prior review existed at capture
+  time): `CURRENT_REVIEW_ID` is non-empty and differs from the baseline, with nothing
+  actionable. Copilot has reviewed and left nothing to address — go to Step 8 immediately.
 - **`PENDING`** — no new review yet, or this was a no-baseline capture call (see below) with
   nothing already actionable. Wait 60 seconds and call again.
 - **`ERROR`** — a `gh api` call itself failed (network, auth, or the PR/repo not found). Do

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -88,18 +88,24 @@ It prints four lines:
 THREAD_COUNT=<n>
 SUPPRESSED_COUNT=<n>
 CURRENT_REVIEW_ID=<id or empty>
-DECISION=ACTIONABLE|CLEAN|PENDING
+DECISION=ACTIONABLE|CLEAN|PENDING|ERROR
 ```
 
 - **`ACTIONABLE`** — `THREAD_COUNT` or `SUPPRESSED_COUNT` is non-zero. Exit the poll loop and
   go to Step 4.
-- **`CLEAN`** — `CURRENT_REVIEW_ID` is non-empty and differs from the `baseline_review_id`
-  argument, with nothing actionable. Copilot has reviewed and left nothing to address — go to
-  Step 8 immediately.
-- **`PENDING`** — no new review yet. Wait 60 seconds and call again.
+- **`CLEAN`** — only possible when a `baseline_review_id` argument was supplied: it is
+  non-empty and `CURRENT_REVIEW_ID` differs from it, with nothing actionable. Copilot has
+  reviewed and left nothing to address — go to Step 8 immediately.
+- **`PENDING`** — no new review yet, or this was a no-baseline capture call (see below) with
+  nothing already actionable. Wait 60 seconds and call again.
+- **`ERROR`** — a `gh api` call itself failed (network, auth, or the PR/repo not found). Do
+  not treat this as `PENDING` — stop polling and report the failure to the user instead of
+  looping until exhaustion.
 
-Always exits 0 regardless of which decision it prints — branch on the `DECISION` line, not
-the exit code.
+Exits 0 for any well-formed call, including `DECISION=ERROR` — branch on the `DECISION` line,
+not the exit code. Exits 2 with a usage message on stderr for a malformed invocation (wrong
+argument count, or an `{owner}`/`{repo}`/`{number}` that doesn't match GitHub's own identifier
+charset).
 
 ### Capture baseline Copilot review ID (before the poll loop)
 
@@ -124,7 +130,9 @@ bash "<skill-base-dir>/scripts/check-review-status.sh" {owner} {repo} {number} {
 ```
 
 `DECISION=ACTIONABLE` → exit the poll loop and continue to Step 4. `DECISION=CLEAN` → go to
-Step 8 immediately. `DECISION=PENDING` → wait 60 seconds and repeat.
+Step 8 immediately. `DECISION=PENDING` → wait 60 seconds and repeat. `DECISION=ERROR` → stop
+polling immediately and report the failure to the user — do not count it as a `PENDING`
+attempt or keep retrying silently.
 
 After 10 `PENDING` attempts, call the script one final time with the same arguments. If that
 final call is still `PENDING`, Copilot has not yet reviewed or has nothing actionable —

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -69,68 +69,73 @@ Get `{owner}/{repo}` from:
 gh repo view --json nameWithOwner --jq '.nameWithOwner'
 ```
 
-### Capture baseline Copilot review ID (before the poll loop)
+### The status-check script
 
-Run once before polling begins. Records the latest Copilot review ID so the loop can detect when a new review is submitted.
+Steps 3 and 7 both need the same three checks — unresolved Copilot threads, suppressed
+comments folded into the review body, and whether a new review has landed — so both call one
+bundled script rather than repeating the `gh api`/GraphQL/jq logic inline:
+`scripts/check-review-status.sh`, resolved relative to **this skill's own base directory**
+(the path shown as "Base directory for this skill" when `address-copilot-comments` was
+invoked) — not the current working directory, which is the target repo being worked on:
 
 ```bash
-BASELINE_REVIEW_ID=$(gh api "repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
+bash "<skill-base-dir>/scripts/check-review-status.sh" {owner} {repo} {number} [baseline_review_id]
 ```
 
-Empty result means no Copilot review exists yet — any review that appears during polling is considered new.
+It prints four lines:
+
+```text
+THREAD_COUNT=<n>
+SUPPRESSED_COUNT=<n>
+CURRENT_REVIEW_ID=<id or empty>
+DECISION=ACTIONABLE|CLEAN|PENDING
+```
+
+- **`ACTIONABLE`** — `THREAD_COUNT` or `SUPPRESSED_COUNT` is non-zero. Exit the poll loop and
+  go to Step 4.
+- **`CLEAN`** — `CURRENT_REVIEW_ID` is non-empty and differs from the `baseline_review_id`
+  argument, with nothing actionable. Copilot has reviewed and left nothing to address — go to
+  Step 8 immediately.
+- **`PENDING`** — no new review yet. Wait 60 seconds and call again.
+
+Always exits 0 regardless of which decision it prints — branch on the `DECISION` line, not
+the exit code.
+
+### Capture baseline Copilot review ID (before the poll loop)
+
+Run the script once before polling begins, with no `baseline_review_id` argument, and take
+`CURRENT_REVIEW_ID` from its output as the baseline for every later call in this round:
+
+```bash
+bash "<skill-base-dir>/scripts/check-review-status.sh" {owner} {repo} {number}
+```
+
+If this first call already prints `DECISION=ACTIONABLE`, skip the poll loop entirely and go
+straight to Step 4 — there's no need to wait when something is already there to address. An
+empty `CURRENT_REVIEW_ID` means no Copilot review exists yet; any review that appears during
+polling is considered new.
 
 ### Poll loop (every 60 seconds, max 10 attempts)
 
-**Step A — Thread count check.** Use GraphQL — the REST `pulls/{number}/comments` endpoint misses threads posted as part of a review submission:
+Call the script again on each iteration, passing the baseline captured above:
 
 ```bash
-gh api graphql -f query='
-query {
-  repository(owner: "{owner}", name: "{repo}") {
-    pullRequest(number: {number}) {
-      reviewThreads(first: 100) {
-        nodes {
-          isResolved
-          comments(first: 1) {
-            nodes { author { login } }
-          }
-        }
-      }
-    }
-  }
-}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | test("copilot"; "i"))] | length'
+bash "<skill-base-dir>/scripts/check-review-status.sh" {owner} {repo} {number} {baseline_review_id}
 ```
 
-**Step A2 — Suppressed comments check.** Run every iteration alongside Step A — do not skip this because Step A already found threads. A round can have both real threads and suppressed comments at once, and Step 4 relies on this check having actually run to know about any suppressed entries. Fetch the latest Copilot review body and check for a `### Suppressed comments (N)` block:
+`DECISION=ACTIONABLE` → exit the poll loop and continue to Step 4. `DECISION=CLEAN` → go to
+Step 8 immediately. `DECISION=PENDING` → wait 60 seconds and repeat.
 
-```bash
-REVIEW_BODY=$(gh api "repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .body // empty')
+After 10 `PENDING` attempts, call the script one final time with the same arguments. If that
+final call is still `PENDING`, Copilot has not yet reviewed or has nothing actionable —
+continue to Step 8.
 
-SUPPRESSED_COUNT=$(printf '%s' "$REVIEW_BODY" | grep -oE 'Suppressed comments \([0-9]+\)' | grep -oE '[0-9]+' | head -1)
-SUPPRESSED_COUNT=${SUPPRESSED_COUNT:-0}
-```
-
-Suppressed comments have no `databaseId`/thread ID — they are markdown text embedded in the review body's collapsible `<details>` block (GitHub's Copilot reviewer folds some findings there instead of posting them as real review comments), not real PR review comments, so they never appear as `reviewThreads` and Step A's count reads 0 even when these exist.
-
-**Decision.** If the Step A count > 0 **or** `SUPPRESSED_COUNT` > 0 — exit the poll loop and continue to Step 4, carrying forward `$REVIEW_BODY` for Step 4's suppressed-entry handling.
-
-**Step B — Reviews check (only when thread count = 0 and suppressed count = 0).** Check whether the latest Copilot review ID has changed since the baseline was captured. This re-fetches the same reviews endpoint as Step A2 rather than reusing its result — `gh api --jq` uses `gh`'s bundled jq internally, but combining Step A2 and Step B's extractions into a single call would require piping through a standalone `jq` binary, which isn't guaranteed to be on `PATH` even where `gh` is. The extra request is the safer trade:
-
-```bash
-# Same query as baseline capture above — assigns to CURRENT_REVIEW_ID
-CURRENT_REVIEW_ID=$(gh api "repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
-```
-
-Then:
-
-If `CURRENT_REVIEW_ID` is non-empty and differs from `BASELINE_REVIEW_ID` — Copilot has submitted a new review with no actionable threads. **Go to Step 8 immediately.**
-
-If `CURRENT_REVIEW_ID` equals `BASELINE_REVIEW_ID` (or is still empty) — no new review yet. Wait 60 seconds and repeat.
-
-After 10 failed attempts (thread count still 0, suppressed count still 0, and no new review detected), perform one final pass of Steps A, A2, and B with the same queries. If the final pass also returns 0 threads, 0 suppressed comments, and no new review, Copilot has not yet reviewed or has nothing actionable — continue to Step 8.
+Suppressed comments have no `databaseId`/thread ID — they are markdown text embedded in the
+review body's collapsible `<details>` block (GitHub's Copilot reviewer folds some findings
+there instead of posting them as real review comments), not real PR review comments, so they
+never appear as `reviewThreads` and `THREAD_COUNT` reads 0 even when these exist. That's why
+the script checks both counts on every call rather than treating one as a fallback for the
+other — a round can have both real threads and suppressed comments at once.
 
 ---
 
@@ -170,7 +175,14 @@ The query returns two IDs per thread — use the right one for each operation:
 
 ### Suppressed comments (no thread ID)
 
-Suppressed comments come from the same review body already fetched in Step A2 (`$REVIEW_BODY`) — re-fetch it here if it's out of scope. Read the `### Suppressed comments (N)` block directly rather than parsing it with a script: each entry starts with a bold `**path:line**` header line, followed by one or more `*` bullet lines with the finding text, and optionally a fenced code block quoting the affected file content. Treat each entry as its own finding — decide Fix or Push back exactly as for a thread (including the `.agent-docs/` push-back rule), and apply any code changes the same way.
+`check-review-status.sh` reports only the suppressed-comment *count*, not their text — fetch the review body itself here:
+
+```bash
+gh api "repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100" \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .body // empty'
+```
+
+Read the `### Suppressed comments (N)` block directly rather than parsing it with a script: each entry starts with a bold `**path:line**` header line, followed by one or more `*` bullet lines with the finding text, and optionally a fenced code block quoting the affected file content. Treat each entry as its own finding — decide Fix or Push back exactly as for a thread (including the `.agent-docs/` push-back rule), and apply any code changes the same way.
 
 Suppressed entries have no `threadId` or `comment_id` — the reply and resolve steps below apply only to real threads. Skip straight to the "Acknowledge suppressed comments" section for these instead.
 

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -188,7 +188,7 @@ The query returns two IDs per thread — use the right one for each operation:
 
 ```bash
 gh api "repos/{owner}/{repo}/pulls/{number}/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .body // empty'
+  --jq '[.[] | select((.user.login // "") | test("copilot";"i"))] | last | .body // empty'
 ```
 
 Read the `### Suppressed comments (N)` block directly rather than parsing it with a script: each entry starts with a bold `**path:line**` header line, followed by one or more `*` bullet lines with the finding text, and optionally a fenced code block quoting the affected file content. Treat each entry as its own finding — decide Fix or Push back exactly as for a thread (including the `.agent-docs/` push-back rule), and apply any code changes the same way.

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -81,15 +81,13 @@ See the Decide Whether Copilot Review Is Required section in [REFERENCE.md](REFE
 
 ## Step 3 — Poll for Copilot review threads and suppressed comments
 
-Before polling, capture the latest Copilot review ID as a baseline (empty if no review exists yet).
+Both the thread-count check and the suppressed-comments check (a round can have both at once — suppressed comments are actionable Copilot findings folded into the review body's markdown instead of posted as real reviewThreads, so they never show up in the thread count even though they're unaddressed) run via one bundled script rather than inline commands — see the status-check script section in [REFERENCE.md](REFERENCE.md).
 
-Poll every 60 seconds, max 10 attempts:
+Before polling, capture the latest Copilot review ID as a baseline by calling the script once with no baseline argument (empty if no review exists yet; if this call already reports something actionable, skip straight to Step 4).
 
-1. Run the thread count check **and** the suppressed-comments check (both, every iteration — don't short-circuit one on the other, a round can have both real threads and suppressed comments at once). If either is non-zero, exit to Step 4. Suppressed comments are actionable Copilot findings folded into the review body's markdown instead of posted as real reviewThreads — they have no `databaseId`/thread ID, so they never show up in the thread count check even though they're unaddressed.
-2. If both checks are 0/absent, check whether the latest Copilot review ID is non-empty and differs from the baseline. If yes, Copilot reviewed clean — go to Step 8 immediately.
-3. If no new review, wait and repeat.
+Poll every 60 seconds, max 10 attempts, calling the script again each time: an actionable result exits to Step 4; a clean result (a new review with nothing to address) goes to Step 8 immediately; a failed `gh api` call is reported distinctly and must not be treated as "wait and retry"; otherwise wait and repeat.
 
-After 10 attempts with no new clean review, perform one final check following the same branching: threads > 0 or suppressed comments > 0 → exit to Step 4; otherwise go to Step 8. See the Poll for Copilot Review Threads and Suppressed Comments section in [REFERENCE.md](REFERENCE.md) for the queries.
+After 10 attempts with no new clean review, call the script one final time following the same branching. See the status-check script section in [REFERENCE.md](REFERENCE.md) for the full command and output contract.
 
 ## Step 4 — Decide and apply changes
 

--- a/address-copilot-comments/scripts/check-review-status.sh
+++ b/address-copilot-comments/scripts/check-review-status.sh
@@ -71,21 +71,17 @@ query($owner: String!, $repo: String!, $number: Int!) {
   --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | test("copilot"; "i"))] | length')
 THREAD_OK=$?
 
-REVIEW_BODY=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .body // empty')
-BODY_OK=$?
+# One call for both the id and the body: `--jq`'s comma operator emits each as its own
+# top-level result, and gh prints one raw-text result per line — the id is always a single
+# line (a bare number or empty), so it always occupies line 1, with the (possibly multi-line)
+# body making up everything from line 2 on. No delimiter or encoding is needed to split them.
+REVIEWS_RESULT=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | (.id // empty), (.body // empty)')
+REVIEWS_OK=$?
+CURRENT_REVIEW_ID=$(printf '%s\n' "$REVIEWS_RESULT" | head -1)
+REVIEW_BODY=$(printf '%s\n' "$REVIEWS_RESULT" | tail -n +2)
 
-# A second, identical-endpoint call rather than reusing the one above. `gh api --jq` could
-# extract both fields in one request (e.g. via @tsv), but a review body is arbitrary
-# multi-line markdown — safely combining it with a single-line id in one delimited output
-# would need base64-style encoding, whose decode flag differs between GNU (`base64 -d`) and
-# BSD/macOS (`base64 -D`) coreutils. Two simple, single-value calls avoid that portability
-# split; the extra request is the accepted trade-off.
-CURRENT_REVIEW_ID=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
-ID_OK=$?
-
-if [ "$THREAD_OK" -ne 0 ] || [ "$BODY_OK" -ne 0 ] || [ "$ID_OK" -ne 0 ]; then
+if [ "$THREAD_OK" -ne 0 ] || [ "$REVIEWS_OK" -ne 0 ]; then
   echo "THREAD_COUNT="
   echo "SUPPRESSED_COUNT="
   echo "CURRENT_REVIEW_ID="

--- a/address-copilot-comments/scripts/check-review-status.sh
+++ b/address-copilot-comments/scripts/check-review-status.sh
@@ -4,14 +4,18 @@
 # Usage: check-review-status.sh <owner> <repo> <pr_number> [baseline_review_id]
 #
 # Prints, one per line:
-#   THREAD_COUNT=<n>
-#   SUPPRESSED_COUNT=<n>
+#   THREAD_COUNT=<n>          (always numeric, including 0 on ERROR)
+#   SUPPRESSED_COUNT=<n>      (always numeric, including 0 on ERROR)
 #   CURRENT_REVIEW_ID=<id or empty>
 #   DECISION=ACTIONABLE|CLEAN|PENDING|ERROR
 #
 # ACTIONABLE — unresolved Copilot threads or suppressed comments exist; go to Step 4.
-# CLEAN      — called WITH a baseline (4th argument supplied) and CURRENT_REVIEW_ID is
-#              non-empty and differs from it, with nothing actionable; go to Step 8.
+# CLEAN      — called WITH a baseline (4th argument supplied, even if it was itself an empty
+#              string), CURRENT_REVIEW_ID is non-empty, and it differs from the baseline, with
+#              nothing actionable; go to Step 8. The baseline itself may legitimately be
+#              empty (it means no prior review existed at capture time) — what matters is
+#              that a baseline argument was supplied at all (see HAS_BASELINE below), not
+#              that its value is non-empty.
 # PENDING    — no new review yet, or this is the no-baseline capture call (see below) and
 #              nothing is already actionable; wait and call again.
 # ERROR      — a `gh api` call itself failed (network/auth/not-found). Never treated as
@@ -82,8 +86,8 @@ CURRENT_REVIEW_ID=$(printf '%s\n' "$REVIEWS_RESULT" | head -1)
 REVIEW_BODY=$(printf '%s\n' "$REVIEWS_RESULT" | tail -n +2)
 
 if [ "$THREAD_OK" -ne 0 ] || [ "$REVIEWS_OK" -ne 0 ]; then
-  echo "THREAD_COUNT="
-  echo "SUPPRESSED_COUNT="
+  echo "THREAD_COUNT=0"
+  echo "SUPPRESSED_COUNT=0"
   echo "CURRENT_REVIEW_ID="
   echo "DECISION=ERROR"
   exit 0

--- a/address-copilot-comments/scripts/check-review-status.sh
+++ b/address-copilot-comments/scripts/check-review-status.sh
@@ -7,27 +7,52 @@
 #   THREAD_COUNT=<n>
 #   SUPPRESSED_COUNT=<n>
 #   CURRENT_REVIEW_ID=<id or empty>
-#   DECISION=ACTIONABLE|CLEAN|PENDING
+#   DECISION=ACTIONABLE|CLEAN|PENDING|ERROR
 #
 # ACTIONABLE — unresolved Copilot threads or suppressed comments exist; go to Step 4.
-# CLEAN      — a new Copilot review exists (differs from baseline) with nothing actionable;
-#              go to Step 8.
-# PENDING    — no new review yet; wait and call again.
+# CLEAN      — called WITH a baseline (4th argument supplied) and CURRENT_REVIEW_ID is
+#              non-empty and differs from it, with nothing actionable; go to Step 8.
+# PENDING    — no new review yet, or this is the no-baseline capture call (see below) and
+#              nothing is already actionable; wait and call again.
+# ERROR      — a `gh api` call itself failed (network/auth/not-found). Never treated as
+#              PENDING — stop and report to the user instead of looping forever.
 #
-# Called with no baseline_review_id, this also serves as the one-time baseline capture:
-# take CURRENT_REVIEW_ID from the output as the baseline for later calls. Always exits 0 —
-# callers branch on DECISION, not the exit code.
+# Called with only 3 arguments (no baseline), this also serves as the one-time baseline
+# capture: take CURRENT_REVIEW_ID from the output as the baseline for later calls. This mode
+# never reports CLEAN, since there's nothing yet to compare CURRENT_REVIEW_ID against.
+#
+# Exits 0 for any well-formed call, including DECISION=ERROR — branch on DECISION, not the
+# exit code. Exits 2 with a usage message on stderr for a malformed invocation (wrong
+# argument count, or an owner/repo/pr_number that doesn't look like a real GitHub identifier).
 set -u
+
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+  echo "Usage: check-review-status.sh <owner> <repo> <pr_number> [baseline_review_id]" >&2
+  exit 2
+fi
 
 OWNER="$1"
 REPO="$2"
 PR="$3"
 BASELINE="${4:-}"
 
+if [ "$#" -eq 4 ]; then
+  HAS_BASELINE=1
+else
+  HAS_BASELINE=0
+fi
+
+# owner/repo/PR flow into a GraphQL query and a REST path below — validate against GitHub's
+# own identifier charset first rather than trusting the caller.
+if ! [[ "$OWNER" =~ ^[A-Za-z0-9-]+$ ]] || ! [[ "$REPO" =~ ^[A-Za-z0-9._-]+$ ]] || ! [[ "$PR" =~ ^[0-9]+$ ]]; then
+  echo "Invalid owner/repo/pr_number: must match GitHub's own identifier charset." >&2
+  exit 2
+fi
+
 THREAD_COUNT=$(gh api graphql -f query='
-query {
-  repository(owner: "'"$OWNER"'", name: "'"$REPO"'") {
-    pullRequest(number: '"$PR"') {
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
       reviewThreads(first: 100) {
         nodes {
           isResolved
@@ -38,20 +63,36 @@ query {
       }
     }
   }
-}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | test("copilot"; "i"))] | length')
+}' -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | test("copilot"; "i"))] | length')
+THREAD_OK=$?
 
 REVIEW_BODY=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
   --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .body // empty')
+BODY_OK=$?
+
+# A second, identical-endpoint call rather than reusing the one above — combining both
+# extractions into a single call would require piping the already-fetched JSON through a
+# standalone `jq` binary, which isn't guaranteed to be on PATH even where `gh` is. The extra
+# request is the accepted trade-off.
+CURRENT_REVIEW_ID=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
+ID_OK=$?
+
+if [ "$THREAD_OK" -ne 0 ] || [ "$BODY_OK" -ne 0 ] || [ "$ID_OK" -ne 0 ]; then
+  echo "THREAD_COUNT="
+  echo "SUPPRESSED_COUNT="
+  echo "CURRENT_REVIEW_ID="
+  echo "DECISION=ERROR"
+  exit 0
+fi
 
 SUPPRESSED_COUNT=$(printf '%s' "$REVIEW_BODY" | grep -oE 'Suppressed comments \([0-9]+\)' | grep -oE '[0-9]+' | head -1)
 SUPPRESSED_COUNT=${SUPPRESSED_COUNT:-0}
 
-CURRENT_REVIEW_ID=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
-
 if [ "$THREAD_COUNT" -gt 0 ] || [ "$SUPPRESSED_COUNT" -gt 0 ]; then
   DECISION="ACTIONABLE"
-elif [ -n "$CURRENT_REVIEW_ID" ] && [ "$CURRENT_REVIEW_ID" != "$BASELINE" ]; then
+elif [ "$HAS_BASELINE" -eq 1 ] && [ -n "$CURRENT_REVIEW_ID" ] && [ "$CURRENT_REVIEW_ID" != "$BASELINE" ]; then
   DECISION="CLEAN"
 else
   DECISION="PENDING"

--- a/address-copilot-comments/scripts/check-review-status.sh
+++ b/address-copilot-comments/scripts/check-review-status.sh
@@ -73,6 +73,10 @@ query($owner: String!, $repo: String!, $number: Int!) {
   }
 }' -f owner="$OWNER" -f repo="$REPO" -F number="$PR" \
   --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select((.comments.nodes[0].author.login // "") | test("copilot"; "i"))] | length')
+# The `// ""` above guards against `test()` erroring on a null login (a thread with no
+# comments, or whose first comment's author is a deleted/unavailable GitHub account) — without
+# it, one such thread fails the whole GraphQL call and misreports a successful response as
+# DECISION=ERROR. The same guard is applied to .user.login below for the same reason.
 THREAD_OK=$?
 
 # One call for both the id and the body: `--jq`'s comma operator emits each as its own
@@ -80,7 +84,7 @@ THREAD_OK=$?
 # line (a bare number or empty), so it always occupies line 1, with the (possibly multi-line)
 # body making up everything from line 2 on. No delimiter or encoding is needed to split them.
 REVIEWS_RESULT=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
-  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | (.id // empty), (.body // empty)')
+  --jq '[.[] | select((.user.login // "") | test("copilot";"i"))] | last | (.id // empty), (.body // empty)')
 REVIEWS_OK=$?
 CURRENT_REVIEW_ID=$(printf '%s\n' "$REVIEWS_RESULT" | head -1)
 REVIEW_BODY=$(printf '%s\n' "$REVIEWS_RESULT" | tail -n +2)

--- a/address-copilot-comments/scripts/check-review-status.sh
+++ b/address-copilot-comments/scripts/check-review-status.sh
@@ -72,7 +72,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
     }
   }
 }' -f owner="$OWNER" -f repo="$REPO" -F number="$PR" \
-  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | test("copilot"; "i"))] | length')
+  --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select((.comments.nodes[0].author.login // "") | test("copilot"; "i"))] | length')
 THREAD_OK=$?
 
 # One call for both the id and the body: `--jq`'s comma operator emits each as its own

--- a/address-copilot-comments/scripts/check-review-status.sh
+++ b/address-copilot-comments/scripts/check-review-status.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Single-iteration Copilot review status check for address-copilot-comments Step 3/Step 7.
+#
+# Usage: check-review-status.sh <owner> <repo> <pr_number> [baseline_review_id]
+#
+# Prints, one per line:
+#   THREAD_COUNT=<n>
+#   SUPPRESSED_COUNT=<n>
+#   CURRENT_REVIEW_ID=<id or empty>
+#   DECISION=ACTIONABLE|CLEAN|PENDING
+#
+# ACTIONABLE — unresolved Copilot threads or suppressed comments exist; go to Step 4.
+# CLEAN      — a new Copilot review exists (differs from baseline) with nothing actionable;
+#              go to Step 8.
+# PENDING    — no new review yet; wait and call again.
+#
+# Called with no baseline_review_id, this also serves as the one-time baseline capture:
+# take CURRENT_REVIEW_ID from the output as the baseline for later calls. Always exits 0 —
+# callers branch on DECISION, not the exit code.
+set -u
+
+OWNER="$1"
+REPO="$2"
+PR="$3"
+BASELINE="${4:-}"
+
+THREAD_COUNT=$(gh api graphql -f query='
+query {
+  repository(owner: "'"$OWNER"'", name: "'"$REPO"'") {
+    pullRequest(number: '"$PR"') {
+      reviewThreads(first: 100) {
+        nodes {
+          isResolved
+          comments(first: 1) {
+            nodes { author { login } }
+          }
+        }
+      }
+    }
+  }
+}' --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | test("copilot"; "i"))] | length')
+
+REVIEW_BODY=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .body // empty')
+
+SUPPRESSED_COUNT=$(printf '%s' "$REVIEW_BODY" | grep -oE 'Suppressed comments \([0-9]+\)' | grep -oE '[0-9]+' | head -1)
+SUPPRESSED_COUNT=${SUPPRESSED_COUNT:-0}
+
+CURRENT_REVIEW_ID=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
+  --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
+
+if [ "$THREAD_COUNT" -gt 0 ] || [ "$SUPPRESSED_COUNT" -gt 0 ]; then
+  DECISION="ACTIONABLE"
+elif [ -n "$CURRENT_REVIEW_ID" ] && [ "$CURRENT_REVIEW_ID" != "$BASELINE" ]; then
+  DECISION="CLEAN"
+else
+  DECISION="PENDING"
+fi
+
+echo "THREAD_COUNT=$THREAD_COUNT"
+echo "SUPPRESSED_COUNT=$SUPPRESSED_COUNT"
+echo "CURRENT_REVIEW_ID=$CURRENT_REVIEW_ID"
+echo "DECISION=$DECISION"

--- a/address-copilot-comments/scripts/check-review-status.sh
+++ b/address-copilot-comments/scripts/check-review-status.sh
@@ -49,6 +49,10 @@ if ! [[ "$OWNER" =~ ^[A-Za-z0-9-]+$ ]] || ! [[ "$REPO" =~ ^[A-Za-z0-9._-]+$ ]] |
   exit 2
 fi
 
+# -f always sends a string (needed for owner/repo — an all-digit org or user name is valid
+# on GitHub, and -F's type auto-detection would otherwise send it as a JSON number, which the
+# $owner/$repo: String! variables below would reject). -F sends $number as an actual number,
+# matching its Int! declaration.
 THREAD_COUNT=$(gh api graphql -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
@@ -63,7 +67,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
       }
     }
   }
-}' -F owner="$OWNER" -F repo="$REPO" -F number="$PR" \
+}' -f owner="$OWNER" -f repo="$REPO" -F number="$PR" \
   --jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false) | select(.comments.nodes[0].author.login | test("copilot"; "i"))] | length')
 THREAD_OK=$?
 
@@ -71,10 +75,12 @@ REVIEW_BODY=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
   --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .body // empty')
 BODY_OK=$?
 
-# A second, identical-endpoint call rather than reusing the one above — combining both
-# extractions into a single call would require piping the already-fetched JSON through a
-# standalone `jq` binary, which isn't guaranteed to be on PATH even where `gh` is. The extra
-# request is the accepted trade-off.
+# A second, identical-endpoint call rather than reusing the one above. `gh api --jq` could
+# extract both fields in one request (e.g. via @tsv), but a review body is arbitrary
+# multi-line markdown — safely combining it with a single-line id in one delimited output
+# would need base64-style encoding, whose decode flag differs between GNU (`base64 -d`) and
+# BSD/macOS (`base64 -D`) coreutils. Two simple, single-value calls avoid that portability
+# split; the extra request is the accepted trade-off.
 CURRENT_REVIEW_ID=$(gh api "repos/$OWNER/$REPO/pulls/$PR/reviews?per_page=100" \
   --jq '[.[] | select(.user.login | test("copilot";"i"))] | last | .id // empty')
 ID_OK=$?


### PR DESCRIPTION
## Summary

address-copilot-comments's poll logic (baseline review-ID capture, an unresolved-thread GraphQL query, a suppressed-comment body fetch, a current-review-ID fetch) was written out as inline bash blocks twice: once for Step 3's poll loop and again for Step 7's re-poll. Extracts the checks into one bundled script, address-copilot-comments/scripts/check-review-status.sh, that both steps call, reporting a single DECISION value (ACTIONABLE/CLEAN/PENDING/ERROR).

This is the first executable script bundled with any skill in this repo. Went through 6 code-review rounds that found and fixed: a GraphQL/REST injection risk (now uses bound gh api graphql variables plus charset validation), silent swallowing of gh api failures (now DECISION=ERROR instead of falling through to PENDING), a false CLEAN on the no-baseline capture call, an undocumented crash under set -u on malformed invocation, incorrect GraphQL variable typing for all-digit owner/repo names, a stale SKILL.md cross-reference, a spec self-contradiction, and finally merging two duplicate API calls into one.

Closes #46.

## Test plan

- [x] pre-commit-check passes on all changed files (both changed-files and full-repo passes).
- [x] Verified live against a real PR (mholubinka1/skills#45) across all four DECISION paths (ACTIONABLE via #43's suppressed comments, CLEAN, PENDING, ERROR via a nonexistent PR).
- [x] Verified injection-safety (malformed owner with embedded quote) and usage-error (wrong arg count) both exit 2 with a clear message rather than crashing.
- [x] Two consecutive code-review passes (Standards + Spec axes) with zero findings.