### PR TITLE
Require Step 4b to run synchronously in the foreground

### DIFF
--- a/.agent-docs/issues/chore/step4b-foreground-requirement.md
+++ b/.agent-docs/issues/chore/step4b-foreground-requirement.md
@@ -1,0 +1,29 @@
+# Issues: chore/step4b-foreground-requirement
+
+## Require Step 4b to run synchronously in the foreground
+
+**GitHub**: #50
+
+**Blocked by**: None
+
+**User stories**: 1, 2
+
+### What to build
+
+Add a sentence to `address-copilot-comments/SKILL.md` Step 4b's existing "MUST NOT SKIP"
+callout: the validation must run synchronously in the foreground and fully complete —
+including any fixes it produces being committed — before Step 4c proceeds. Never dispatched
+as a background agent while the main thread continues.
+
+### Acceptance criteria
+
+- [ ] Step 4b's callout in `address-copilot-comments/SKILL.md` states the validation must run
+      synchronously in the foreground.
+- [ ] The callout states the validation must fully complete (including committing any fixes
+      it produces) before Step 4c proceeds.
+- [ ] The callout explicitly forbids dispatching the validation as a background agent while
+      the main thread continues.
+- [ ] No other wording in Step 4b or elsewhere in SKILL.md changes.
+- [ ] `pre-commit-check` passes on the file.
+
+---

--- a/.agent-docs/issues/chore/step4b-foreground-requirement.md
+++ b/.agent-docs/issues/chore/step4b-foreground-requirement.md
@@ -12,15 +12,19 @@
 
 Add a sentence to `address-copilot-comments/SKILL.md` Step 4b's existing "MUST NOT SKIP"
 callout: the validation must run synchronously in the foreground and fully complete —
-including any fixes it produces being committed — before Step 4c proceeds. Never dispatched
-as a background agent while the main thread continues.
+including any fixes it applies — before Step 4c and this round's Step 5 commit. Never
+dispatched as a background agent while the main thread continues. Note that `code-review`
+Steps 1–5 don't themselves commit anything (Step 5 there is "apply fixes, then re-run
+pre-commit hooks") — the commit happens later, in `address-copilot-comments`' own Step 5, so
+the requirement is that Step 4b's fixes land before that commit, not that Step 4b commits
+them.
 
 ### Acceptance criteria
 
 - [ ] Step 4b's callout in `address-copilot-comments/SKILL.md` states the validation must run
       synchronously in the foreground.
-- [ ] The callout states the validation must fully complete (including committing any fixes
-      it produces) before Step 4c proceeds.
+- [ ] The callout states the validation (including any fixes it applies) must fully complete
+      before Step 4c and this round's Step 5 commit, without claiming Step 4b itself commits.
 - [ ] The callout explicitly forbids dispatching the validation as a background agent while
       the main thread continues.
 - [ ] No other wording in Step 4b or elsewhere in SKILL.md changes.

--- a/.agent-docs/issues/chore/step4b-foreground-requirement.md
+++ b/.agent-docs/issues/chore/step4b-foreground-requirement.md
@@ -1,5 +1,7 @@
 # Issues: chore/step4b-foreground-requirement
 
+> Work complete — PR ready to merge.
+
 ## Require Step 4b to run synchronously in the foreground
 
 **GitHub**: #50
@@ -21,13 +23,13 @@ them.
 
 ### Acceptance criteria
 
-- [ ] Step 4b's callout in `address-copilot-comments/SKILL.md` states the validation must run
+- [x] Step 4b's callout in `address-copilot-comments/SKILL.md` states the validation must run
       synchronously in the foreground.
-- [ ] The callout states the validation (including any fixes it applies) must fully complete
+- [x] The callout states the validation (including any fixes it applies) must fully complete
       before Step 4c and this round's Step 5 commit, without claiming Step 4b itself commits.
-- [ ] The callout explicitly forbids dispatching the validation as a background agent while
+- [x] The callout explicitly forbids dispatching the validation as a background agent while
       the main thread continues.
-- [ ] No other wording in Step 4b or elsewhere in SKILL.md changes.
-- [ ] `pre-commit-check` passes on the file.
+- [x] No other wording in Step 4b or elsewhere in SKILL.md changes.
+- [x] `pre-commit-check` passes on the file.
 
 ---

--- a/.agent-docs/specs/chore/step4b-foreground-requirement.md
+++ b/.agent-docs/specs/chore/step4b-foreground-requirement.md
@@ -1,0 +1,58 @@
+# Require Step 4b to Run Synchronously in the Foreground
+
+## Problem Statement
+
+`address-copilot-comments/SKILL.md` Step 4b already has a "MUST NOT SKIP" callout requiring
+`code-review` Steps 1–5 to run whenever a fix was applied, but it says nothing about *how*
+that validation must be invoked. In a real session, Step 4b's validation was dispatched as a
+background agent after the round-2 fixes had already been committed and pushed — the reverse
+of the intended "validate, then commit" order. It happened to be safe that time (the
+background agent only found a minor issue, fixed separately), but a background agent editing
+the same files the main thread might also be touching mid-review is a real coordination
+hazard: two processes could make conflicting edits to the same file with neither aware of the
+other.
+
+## Solution
+
+Add a sentence to Step 4b's existing callout: the validation must run synchronously in the
+foreground and fully complete — including any fixes it produces being committed — before
+Step 4c proceeds. Never dispatched as a background agent while the main thread continues.
+
+## User Stories
+
+1. As an agent following `address-copilot-comments`, I want Step 4b to explicitly forbid
+   backgrounding its own validation, so that I don't dispatch it as a background task and
+   move on to committing before it finishes.
+2. As a developer relying on this skill, I want validation to always precede commit/push, so
+   that a background validation agent never edits files concurrently with (or after) the main
+   thread's own commit, which could silently conflict or get lost.
+
+## Implementation Decisions
+
+- File touched: `address-copilot-comments/SKILL.md` only, within Step 4b's existing
+  `> **MUST NOT SKIP.**` callout.
+- Added sentence: the validation must run synchronously in the foreground and complete
+  entirely — including any fixes it produces being committed — before Step 4c proceeds; never
+  dispatched as a background agent while the main thread continues to Step 4c/5.
+- No REFERENCE.md change: Step 4b has no corresponding REFERENCE.md section (its content is
+  fully inline in SKILL.md already), so there is nothing else to update.
+- No ADR: reverting a single sentence in an existing callout is trivial.
+
+## Testing Decisions
+
+- No code seam; this is a workflow-instruction document. Verified by review (does the added
+  sentence read clearly and sit correctly within the existing callout) and by
+  `pre-commit-check` (markdown lint).
+
+## Out of Scope
+
+- Any other Step in `address-copilot-comments` or `code-review` — this only touches Step 4b's
+  own callout.
+- Enforcing this programmatically (e.g. via a hook that blocks backgrounded Agent calls) —
+  this stays a documented instruction, matching how every other skill-workflow rule in this
+  repo works.
+
+## Further Notes
+
+This is the fourth of six small fixes queued from a retrospective on a recent PR; each is
+being run through its own `/implement` loop rather than bundled together.

--- a/.agent-docs/specs/chore/step4b-foreground-requirement.md
+++ b/.agent-docs/specs/chore/step4b-foreground-requirement.md
@@ -15,8 +15,13 @@ other.
 ## Solution
 
 Add a sentence to Step 4b's existing callout: the validation must run synchronously in the
-foreground and fully complete — including any fixes it produces being committed — before
-Step 4c proceeds. Never dispatched as a background agent while the main thread continues.
+foreground and fully complete — including any fixes it applies — before Step 4c and this
+round's Step 5 commit. Never dispatched as a background agent while the main thread
+continues. Note: `code-review` Steps 1–5 (what Step 4b invokes) don't themselves commit
+anything — Step 5's actual instruction is "apply fixes, then re-run pre-commit hooks"; the
+commit happens later, in `address-copilot-comments`' own Step 5. The requirement is that any
+fixes Step 4b's validation applies land before that later commit, not that Step 4b commits
+them itself.
 
 ## User Stories
 
@@ -32,8 +37,8 @@ Step 4c proceeds. Never dispatched as a background agent while the main thread c
 - File touched: `address-copilot-comments/SKILL.md` only, within Step 4b's existing
   `> **MUST NOT SKIP.**` callout.
 - Added sentence: the validation must run synchronously in the foreground and complete
-  entirely — including any fixes it produces being committed — before Step 4c proceeds; never
-  dispatched as a background agent while the main thread continues to Step 4c/5.
+  entirely — including any fixes it applies — before Step 4c and this round's Step 5 commit;
+  never dispatched as a background agent while the main thread continues.
 - No REFERENCE.md change: Step 4b has no corresponding REFERENCE.md section (its content is
   fully inline in SKILL.md already), so there is nothing else to update.
 - No ADR: reverting a single sentence in an existing callout is trivial.

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -95,7 +95,7 @@ For each unresolved thread, and each suppressed-comment entry found in Step 3/7,
 
 ## Step 4b — Validate changes with code-review
 
-> **MUST NOT SKIP.** The only valid reason to skip this step is if every single decision in Step 4 was a push-back and zero files were modified. Run it synchronously in the foreground and let it fully complete — including committing any fixes it produces — before continuing to Step 4c. Never dispatch it as a background agent while the main thread moves on: a background agent editing the same files the main thread might also touch mid-review is a coordination hazard, not a safe parallelization.
+> **MUST NOT SKIP.** The only valid reason to skip this step is if every single decision in Step 4 was a push-back and zero files were modified. Run it synchronously in the foreground and let it fully complete — including any fixes it applies — before continuing to Step 4c and this round's Step 5 commit, since dispatching it as a background agent while the main thread moves on risks a coordination hazard: a background agent editing the same files the main thread might also touch mid-review.
 
 If at least one fix was applied, run `code-review` Steps 1–5 only. Pass the explicit instruction to stop after Step 5 to avoid re-invoking this skill.
 

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -95,7 +95,7 @@ For each unresolved thread, and each suppressed-comment entry found in Step 3/7,
 
 ## Step 4b — Validate changes with code-review
 
-> **MUST NOT SKIP.** The only valid reason to skip this step is if every single decision in Step 4 was a push-back and zero files were modified. Run it synchronously in the foreground and let it fully complete — including any fixes it applies — before continuing to Step 4c and this round's Step 5 commit, since dispatching it as a background agent while the main thread moves on risks a coordination hazard: a background agent editing the same files the main thread might also touch mid-review.
+> **MUST NOT SKIP.** The only valid reason to skip this step is if every single decision in Step 4 was a push-back and zero files were modified. Run it synchronously in the foreground and let it fully complete — including any fixes it applies — before continuing to Step 4c and this round's Step 5 commit. Never dispatch it as a background agent while the main thread moves on: a background agent editing the same files the main thread might also touch mid-review is a coordination hazard.
 
 If at least one fix was applied, run `code-review` Steps 1–5 only. Pass the explicit instruction to stop after Step 5 to avoid re-invoking this skill.
 

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -95,7 +95,7 @@ For each unresolved thread, and each suppressed-comment entry found in Step 3/7,
 
 ## Step 4b — Validate changes with code-review
 
-> **MUST NOT SKIP.** The only valid reason to skip this step is if every single decision in Step 4 was a push-back and zero files were modified.
+> **MUST NOT SKIP.** The only valid reason to skip this step is if every single decision in Step 4 was a push-back and zero files were modified. Run it synchronously in the foreground and let it fully complete — including committing any fixes it produces — before continuing to Step 4c. Never dispatch it as a background agent while the main thread moves on: a background agent editing the same files the main thread might also touch mid-review is a coordination hazard, not a safe parallelization.
 
 If at least one fix was applied, run `code-review` Steps 1–5 only. Pass the explicit instruction to stop after Step 5 to avoid re-invoking this skill.
 


### PR DESCRIPTION
## Summary

address-copilot-comments's Step 4b already required its code-review validation to run whenever a fix was applied, but said nothing about how it must be invoked. In a real session, Step 4b's validation was dispatched as a background agent after the round-2 fixes had already been committed and pushed - the reverse of the intended "validate, then commit" order. A background agent editing the same files the main thread might also touch mid-review is a real coordination hazard.

Adds an explicit requirement to Step 4b's existing callout: run synchronously in the foreground, let any fixes it applies land before Step 4c and the round's Step 5 commit, and never dispatch it as a background agent.

Closes #50.

## Test plan

- [x] pre-commit-check passes on all changed files (both changed-files and full-repo passes).
- [x] Three internal code-review rounds caught and fixed: a factual error implying code-review's own Steps 1-5 commit changes (they don't - address-copilot-comments' separate Step 5 does), and a softened prohibition that needed restoring to an explicit imperative. Final two rounds clean on both axes.