### PR TITLE
Document Windows python -c Bash-tool gotcha

### DIFF
--- a/.agent-docs/agent.md
+++ b/.agent-docs/agent.md
@@ -68,3 +68,9 @@ These standards apply to all AI agent work in this repository. Follow them on ev
 - Treat review feedback as input to improve the work. Engage with it constructively.
 - Disagree with feedback through productive discussion and reasoning. Do not silently revert to the same pattern on the next task.
 - Contribute context and experience to team decisions. Every level has useful perspective to share.
+
+---
+
+## 7. Environment Notes
+
+- On Windows, via a Bash-tool-style shell: a multi-line `python -c "<script>"` can silently produce no output — no error, just nothing. Write the script to a scratch file and run it directly instead of inlining multi-line Python.

--- a/.agent-docs/issues/chore/python-c-windows-note.md
+++ b/.agent-docs/issues/chore/python-c-windows-note.md
@@ -1,5 +1,7 @@
 # Issues: chore/python-c-windows-note
 
+> Work complete — PR ready to merge.
+
 ## Document Windows python -c Bash-tool gotcha
 
 **GitHub**: #54
@@ -18,13 +20,13 @@ a scratch file and running it directly instead.
 
 ### Acceptance criteria
 
-- [ ] `init-agent-docs/AGENT-TEMPLATE.md` has a new `## 7. Environment Notes` section covering
+- [x] `init-agent-docs/AGENT-TEMPLATE.md` has a new `## 7. Environment Notes` section covering
       this gotcha.
-- [ ] `.agent-docs/agent.md` has the identical section in the identical location.
-- [ ] Both files remain byte-identical after the change.
-- [ ] The note is explicitly scoped to Windows + Bash-tool-style shells, not stated as a
+- [x] `.agent-docs/agent.md` has the identical section in the identical location.
+- [x] Both files remain byte-identical after the change.
+- [x] The note is explicitly scoped to Windows + Bash-tool-style shells, not stated as a
       universal rule.
-- [ ] No existing section's wording changes in either file.
-- [ ] `pre-commit-check` passes on both files.
+- [x] No existing section's wording changes in either file.
+- [x] `pre-commit-check` passes on both files.
 
 ---

--- a/.agent-docs/issues/chore/python-c-windows-note.md
+++ b/.agent-docs/issues/chore/python-c-windows-note.md
@@ -1,0 +1,30 @@
+# Issues: chore/python-c-windows-note
+
+## Document Windows python -c Bash-tool gotcha
+
+**GitHub**: #54
+
+**Blocked by**: None
+
+**User stories**: 1, 2
+
+### What to build
+
+Add a new `## 7. Environment Notes` section to the end of both
+`init-agent-docs/AGENT-TEMPLATE.md` and `.agent-docs/agent.md` (identically), with one bullet
+scoped explicitly to Windows + Bash-tool-style shells, warning that a multi-line
+`python -c "<script>"` can silently produce no output, and recommending writing the script to
+a scratch file and running it directly instead.
+
+### Acceptance criteria
+
+- [ ] `init-agent-docs/AGENT-TEMPLATE.md` has a new `## 7. Environment Notes` section covering
+      this gotcha.
+- [ ] `.agent-docs/agent.md` has the identical section in the identical location.
+- [ ] Both files remain byte-identical after the change.
+- [ ] The note is explicitly scoped to Windows + Bash-tool-style shells, not stated as a
+      universal rule.
+- [ ] No existing section's wording changes in either file.
+- [ ] `pre-commit-check` passes on both files.
+
+---

--- a/.agent-docs/specs/chore/python-c-windows-note.md
+++ b/.agent-docs/specs/chore/python-c-windows-note.md
@@ -1,0 +1,55 @@
+# Document Windows python -c Bash-Tool Gotcha
+
+## Problem Statement
+
+Neither `init-agent-docs/AGENT-TEMPLATE.md` nor this repo's own mirrored `.agent-docs/agent.md`
+documents a previously-observed, reproducible Windows tooling gotcha: invoking a multi-line
+`python -c "<script>"` through a Bash-tool-style shell can silently produce no output — no
+error, just nothing. This has been reproduced more than once and cost debugging time each
+time before the cause was identified.
+
+## Solution
+
+Add a new `## 7. Environment Notes` section to the end of both `AGENT-TEMPLATE.md` and
+`.agent-docs/agent.md`, with one bullet explicitly scoped to Windows + Bash-tool-style shells,
+recommending writing the script to a scratch file and running it directly instead of inlining
+multi-line Python.
+
+## User Stories
+
+1. As an agent working on Windows via a Bash-tool-style shell, I want a documented warning
+   about `python -c` silently failing on multi-line scripts, so that I default to a scratch
+   file instead of losing time to a silent no-output failure.
+2. As a maintainer of this skills repo, I want its own `.agent-docs/agent.md` to carry the
+   same environment note as the template it stamps into other repos, matching fix #5's
+   template/mirror-sync precedent.
+
+## Implementation Decisions
+
+- Files touched: `init-agent-docs/AGENT-TEMPLATE.md` and `.agent-docs/agent.md`, both
+  identically.
+- New section: `## 7. Environment Notes`, appended after the existing `## 6. Communication
+  and Feedback` section — append-only, no interleaving with existing sections' bullets
+  (including fix #5's new Production Code Quality bullet).
+- The note is explicitly scoped to "On Windows, via a Bash-tool-style shell" in its own
+  wording — this is a tooling quirk of one platform/tool combination, not a universal coding
+  standard, and the template is stamped into arbitrary repos regardless of OS or which AI
+  agent reads it. Confirmed with the user this belongs here rather than being dropped, given
+  the scoping caveat.
+- No ADR: reverting a single new section from two files is trivial.
+
+## Testing Decisions
+
+- No code seam; this is a behavioural-standards document. Verified by review (does the note
+  read clearly and correctly scope itself to the affected platform/tool combination) and by
+  `pre-commit-check` (markdown lint).
+
+## Out of Scope
+
+- Any other Environment Notes beyond this one Windows/`python -c` gotcha.
+- Auditing for other template/mirror drift beyond this fix's own change.
+
+## Further Notes
+
+This is the sixth and final fix of six small fixes queued from a retrospective on a recent
+PR; each was run through its own `/implement` loop rather than bundled together.

--- a/init-agent-docs/AGENT-TEMPLATE.md
+++ b/init-agent-docs/AGENT-TEMPLATE.md
@@ -68,3 +68,9 @@ These standards apply to all AI agent work in this repository. Follow them on ev
 - Treat review feedback as input to improve the work. Engage with it constructively.
 - Disagree with feedback through productive discussion and reasoning. Do not silently revert to the same pattern on the next task.
 - Contribute context and experience to team decisions. Every level has useful perspective to share.
+
+---
+
+## 7. Environment Notes
+
+- On Windows, via a Bash-tool-style shell: a multi-line `python -c "<script>"` can silently produce no output — no error, just nothing. Write the script to a scratch file and run it directly instead of inlining multi-line Python.


### PR DESCRIPTION
## Summary

Neither init-agent-docs/AGENT-TEMPLATE.md nor this repo's own mirrored .agent-docs/agent.md documented a reproducible Windows tooling gotcha: invoking a multi-line `python -c "<script>"` through a Bash-tool-style shell can silently produce no output - no error, just nothing. This has been reproduced more than once.

Adds an identical "## 7. Environment Notes" section to both files, explicitly scoped to Windows + Bash-tool-style shells (not stated as a universal rule), recommending writing the script to a scratch file and running it directly instead.

Closes #54. This is the sixth and final fix from the retrospective queue.

## Test plan

- [x] pre-commit-check passes on all changed files (both changed-files and full-repo passes).
- [x] Verified init-agent-docs/AGENT-TEMPLATE.md and .agent-docs/agent.md remain byte-identical after the change.
- [x] Two internal code-review rounds, both zero blocking findings (two advisory scoping observations were already surfaced and accepted during design).