### PR TITLE
Add update-skills command + one-time installer

### DIFF
--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -37,7 +37,7 @@ A command placed on the user's `PATH` by `install.sh` that fast-forwards the loc
 _Avoid_: updater, refresh script, sync command
 
 **`install.sh`**:
-The one-time setup script at the repo root. Adds the repo's `bin/` directory to `PATH` via a marker-delimited block in the user's shell rc file (`~/.zshrc` for zsh, else `~/.bashrc`). Idempotent — re-running replaces a stale block in place.
+The one-time setup script at the repo root. Adds the repo's `bin/` directory to `PATH` via a marker-delimited block in the user's shell rc file (`~/.zshrc` for zsh, else `~/.bashrc`). Idempotent — re-running drops any existing block(s) and re-appends a single current one.
 _Avoid_: installer, bootstrap script
 
 ### Workflow Execution

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -22,6 +22,24 @@ _Avoid_: detail file, command reference, documentation file
 A file used by orchestrating skills (e.g. `implement`) to define a multi-step workflow executed inline in the current conversation rather than delegated to a sub-agent.
 _Avoid_: process file, workflow definition
 
+### Skill Distribution
+
+**`sync_claude_skills.py`**:
+The standard-library script that walks this repo and copies every directory containing a `SKILL.md` into `~/.claude/skills/`. Invoked by the `sync-claude-skills` hook and by `update-skills`.
+_Avoid_: sync script, copier
+
+**`sync-claude-skills` hook**:
+The `post-commit` pre-commit hook that runs `sync_claude_skills.py` after every commit in this repo. Fires only on the machine that commits — `update-skills` covers the pull-and-sync path for machines that only consume skills.
+_Avoid_: sync hook, post-commit hook
+
+**`update-skills`**:
+A command placed on the user's `PATH` by `install.sh` that fast-forwards the local clone to `origin/main`, bootstraps `.venv` and the pre-commit hooks on first run, then runs `sync_claude_skills.py`. Refuses to run on a dirty working tree; never forces or resets. For machines that consume skills rather than develop them.
+_Avoid_: updater, refresh script, sync command
+
+**`install.sh`**:
+The one-time setup script at the repo root. Adds the repo's `bin/` directory to `PATH` via a marker-delimited block in the user's shell rc file (`~/.zshrc` for zsh, else `~/.bashrc`). Idempotent — re-running replaces a stale block in place.
+_Avoid_: installer, bootstrap script
+
 ### Workflow Execution
 
 **Step**:

--- a/.agent-docs/issues/feature/update-skills-command.md
+++ b/.agent-docs/issues/feature/update-skills-command.md
@@ -73,9 +73,10 @@ A checked-in `install.sh` at the repo root, run once after cloning, that puts
    otherwise `~/.bashrc`. Creates it if absent.
 3. Appends a block delimited by `# >>> skills update-skills >>>` /
    `# <<< skills update-skills <<<` markers containing `export PATH="<repo>/bin:$PATH"`.
-4. Idempotent: an existing marker block is rewritten in place (handles a moved clone),
-   never duplicated. If `<repo>/bin` is already on `PATH` and the block is already correct,
-   reports "already set up" and makes no edit.
+4. Idempotent: on any change, existing marker block(s) are dropped and one current block is
+   appended at the end of the file (handles a moved clone; collapses accidental duplicates).
+   If exactly one well-formed block already carries the current PATH line, reports "already
+   set up" and makes no edit.
 5. Prints that the current shell needs a new terminal or `source <rc-file>` to pick up the
    change.
 
@@ -88,7 +89,8 @@ the Git Bash `~/.bashrc` note.
       `PATH`, running `./install.sh` appends exactly one marker-delimited block adding
       `<repo>/bin` to `PATH` to the correct rc file, and prints how to activate it now.
 - [x] **Setup is idempotent** — running `./install.sh` again leaves exactly one marker
-      block; a moved clone's stale block is rewritten in place, never duplicated.
+      block; a moved clone's stale block (and any accidental duplicates) are dropped and one
+      current block is re-appended, never stacked.
 - [x] `install.sh` is executable and passes `shellcheck` via pre-commit.
 - [x] `README.md` documents the one-time step and the Git Bash `.bashrc` convention.
 - [x] `pre-commit-check` passes.

--- a/.agent-docs/issues/feature/update-skills-command.md
+++ b/.agent-docs/issues/feature/update-skills-command.md
@@ -1,0 +1,94 @@
+# Issues: feature/update-skills-command
+
+## `update-skills` refresh command
+
+**GitHub**: #56
+
+**Blocked by**: None
+
+**User stories**: 1, 3, 4, 5, 6, 7
+
+### What to build
+
+A checked-in `bin/update-skills` script (no file extension) that refreshes a machine's
+`~/.claude/skills/` from the repo's `main`. Run from any directory, it:
+
+1. Resolves the repo root from its own location and `cd`s there.
+2. Refuses if the working tree is dirty — prints `git status`, exits non-zero, touches
+   nothing.
+3. Switches to `main` and fast-forwards to `origin/main` (`git pull --ff-only`); a diverged
+   history makes the pull fail and the script exits non-zero without forcing.
+4. Bootstraps only when missing: creates `.venv`, installs `pre-commit` into it, installs
+   the git hooks.
+5. Runs `sync_claude_skills.py` with the resolved interpreter.
+
+Interpreter resolution mirrors the `sync-claude-skills` post-commit hook, same order:
+`.venv/Scripts/python` → `.venv/bin/python` → `python3` → `python`. Works identically on
+macOS and Windows (Git Bash).
+
+Supporting changes: add the `shellcheck-py` hook to `.pre-commit-config.yaml`; add
+`bin/update-skills` to the `.gitattributes` LF rule; add a "Skill Distribution" subsection
+to `.agent-docs/context.md` defining `update-skills`, `install.sh`, and the
+`sync-claude-skills` hook.
+
+### Acceptance criteria
+
+- [ ] **Refresh pulls and syncs** — given `update-skills` runs from any directory with a
+      clean tree, the clone ends on `main` fast-forwarded to `origin/main` and
+      `~/.claude/skills/` reflects the repo's current `SKILL.md` directories.
+- [ ] **First run bootstraps** — given no `.venv` and no installed pre-commit hook, the run
+      creates `.venv`, installs `pre-commit`, installs the hooks, and still completes the
+      sync; a second run skips the bootstrap.
+- [ ] **Dirty tree is refused** — given uncommitted changes, the run prints `git status`,
+      changes no git state, runs no sync, and exits non-zero.
+- [ ] **Diverged `main` is refused** — given local `main` has a commit not on
+      `origin/main`, `git pull --ff-only` fails, the script reports it, and exits non-zero
+      without forcing or resetting.
+- [ ] **Interpreter resolution matches the hook** — the sync is invoked with the same
+      interpreter the `sync-claude-skills` hook resolves, falling back `python3` → `python`
+      when no venv exists.
+- [ ] `shellcheck` runs on `bin/update-skills` via pre-commit and passes clean.
+- [ ] `pre-commit-check` passes.
+
+---
+
+## `install.sh` one-time setup
+
+**GitHub**: #57
+
+**Blocked by**: #56
+
+**User stories**: 2, 6
+
+### What to build
+
+A checked-in `install.sh` at the repo root, run once after cloning, that puts
+`update-skills` on the user's `PATH`:
+
+1. Resolves its own directory as the repo root (`./install.sh` or an absolute path both
+   work).
+2. Picks the rc file from the login shell: `~/.zshrc` when `$SHELL` ends in `zsh`,
+   otherwise `~/.bashrc`. Creates it if absent.
+3. Appends a block delimited by `# >>> skills update-skills >>>` /
+   `# <<< skills update-skills <<<` markers containing `export PATH="<repo>/bin:$PATH"`.
+4. Idempotent: an existing marker block is rewritten in place (handles a moved clone),
+   never duplicated. If `<repo>/bin` is already on `PATH` and the block is already correct,
+   reports "already set up" and makes no edit.
+5. Prints that the current shell needs a new terminal or `source <rc-file>` to pick up the
+   change.
+
+Supporting change: add a "Setup" entry to `README.md` with the `./install.sh` one-liner and
+the Git Bash `~/.bashrc` note.
+
+### Acceptance criteria
+
+- [ ] **Fresh setup puts the command on PATH** — given a clone whose `bin/` is not on
+      `PATH`, running `./install.sh` appends exactly one marker-delimited block adding
+      `<repo>/bin` to `PATH` to the correct rc file, and prints how to activate it now.
+- [ ] **Setup is idempotent** — running `./install.sh` again leaves exactly one marker
+      block; a moved clone's stale block is rewritten in place, never duplicated.
+- [ ] `install.sh` is executable and passes `shellcheck` via pre-commit.
+- [ ] `README.md` documents the one-time step and the Git Bash `.bashrc` convention.
+- [ ] `pre-commit-check` passes.
+
+---

--- a/.agent-docs/issues/feature/update-skills-command.md
+++ b/.agent-docs/issues/feature/update-skills-command.md
@@ -1,5 +1,7 @@
 # Issues: feature/update-skills-command
 
+> Work complete — PR ready to merge.
+
 ## `update-skills` refresh command
 
 **GitHub**: #56
@@ -33,22 +35,22 @@ to `.agent-docs/context.md` defining `update-skills`, `install.sh`, and the
 
 ### Acceptance criteria
 
-- [ ] **Refresh pulls and syncs** — given `update-skills` runs from any directory with a
+- [x] **Refresh pulls and syncs** — given `update-skills` runs from any directory with a
       clean tree, the clone ends on `main` fast-forwarded to `origin/main` and
       `~/.claude/skills/` reflects the repo's current `SKILL.md` directories.
-- [ ] **First run bootstraps** — given no `.venv` and no installed pre-commit hook, the run
+- [x] **First run bootstraps** — given no `.venv` and no installed pre-commit hook, the run
       creates `.venv`, installs `pre-commit`, installs the hooks, and still completes the
       sync; a second run skips the bootstrap.
-- [ ] **Dirty tree is refused** — given uncommitted changes, the run prints `git status`,
+- [x] **Dirty tree is refused** — given uncommitted changes, the run prints `git status`,
       changes no git state, runs no sync, and exits non-zero.
-- [ ] **Diverged `main` is refused** — given local `main` has a commit not on
+- [x] **Diverged `main` is refused** — given local `main` has a commit not on
       `origin/main`, `git pull --ff-only` fails, the script reports it, and exits non-zero
       without forcing or resetting.
-- [ ] **Interpreter resolution matches the hook** — the sync is invoked with the same
+- [x] **Interpreter resolution matches the hook** — the sync is invoked with the same
       interpreter the `sync-claude-skills` hook resolves, falling back `python3` → `python`
       when no venv exists.
-- [ ] `shellcheck` runs on `bin/update-skills` via pre-commit and passes clean.
-- [ ] `pre-commit-check` passes.
+- [x] `shellcheck` runs on `bin/update-skills` via pre-commit and passes clean.
+- [x] `pre-commit-check` passes.
 
 ---
 
@@ -82,13 +84,13 @@ the Git Bash `~/.bashrc` note.
 
 ### Acceptance criteria
 
-- [ ] **Fresh setup puts the command on PATH** — given a clone whose `bin/` is not on
+- [x] **Fresh setup puts the command on PATH** — given a clone whose `bin/` is not on
       `PATH`, running `./install.sh` appends exactly one marker-delimited block adding
       `<repo>/bin` to `PATH` to the correct rc file, and prints how to activate it now.
-- [ ] **Setup is idempotent** — running `./install.sh` again leaves exactly one marker
+- [x] **Setup is idempotent** — running `./install.sh` again leaves exactly one marker
       block; a moved clone's stale block is rewritten in place, never duplicated.
-- [ ] `install.sh` is executable and passes `shellcheck` via pre-commit.
-- [ ] `README.md` documents the one-time step and the Git Bash `.bashrc` convention.
-- [ ] `pre-commit-check` passes.
+- [x] `install.sh` is executable and passes `shellcheck` via pre-commit.
+- [x] `README.md` documents the one-time step and the Git Bash `.bashrc` convention.
+- [x] `pre-commit-check` passes.
 
 ---

--- a/.agent-docs/issues/feature/update-skills-command.md
+++ b/.agent-docs/issues/feature/update-skills-command.md
@@ -25,8 +25,8 @@ A checked-in `bin/update-skills` script (no file extension) that refreshes a mac
 5. Runs `sync_claude_skills.py` with the resolved interpreter.
 
 Interpreter resolution mirrors the `sync-claude-skills` post-commit hook, same order:
-`.venv/Scripts/python` → `.venv/bin/python` → `python3` → `python`. Works identically on
-macOS and Windows (Git Bash).
+`.venv/Scripts/python` → `.venv/Scripts/python.exe` (Git Bash) → `.venv/bin/python` →
+`python3` → `python`. Works identically on macOS and Windows (Git Bash).
 
 Supporting changes: add the `shellcheck-py` hook to `.pre-commit-config.yaml`; add
 `bin/update-skills` to the `.gitattributes` LF rule; add a "Skill Distribution" subsection

--- a/.agent-docs/specs/feature/update-skills-command.md
+++ b/.agent-docs/specs/feature/update-skills-command.md
@@ -71,8 +71,10 @@ moves.
     does not exist it is created.
   - Appends a block delimited by marker comments
     (`# >>> skills update-skills >>>` / `# <<< skills update-skills <<<`) containing
-    `export PATH="<repo>/bin:$PATH"`. Idempotent: if a block with those markers already
-    exists it is replaced (handles a moved clone), not duplicated.
+    `export PATH="<repo>/bin:$PATH"`. Idempotent: any existing marker block(s) are removed
+    and one current block is appended at the end of the file (handles a moved clone;
+    collapses accidental duplicates) — not a literal in-place rewrite, so a refreshed block
+    moves to the end.
   - Prints that the current shell needs a new terminal or `source <rc-file>` to pick up the
     change — a child process cannot mutate its parent shell's environment.
   - If `<repo>/bin` is already on `PATH` and the marker block is already present and
@@ -128,8 +130,8 @@ moves.
      `PATH` is appended to the correct rc file, and the script prints how to activate it
      now.
   2. *Setup is idempotent.* Given `install.sh` has already run, when it runs again, then the
-     rc file still contains exactly one marker block and it is unchanged (or rewritten in
-     place if the clone moved), never duplicated.
+     rc file still contains exactly one marker block — unchanged when already current, or
+     dropped and re-appended (moving to the end) if the clone moved — never stacked.
   3. *Refresh pulls and syncs.* Given `update-skills` is on `PATH` and the tree is clean,
      when it runs from any directory, then the clone is on `main`, fast-forwarded to
      `origin/main`, and `~/.claude/skills/` reflects the repo's current `SKILL.md`

--- a/.agent-docs/specs/feature/update-skills-command.md
+++ b/.agent-docs/specs/feature/update-skills-command.md
@@ -1,0 +1,169 @@
+# `update-skills` Refresh Command
+
+## Problem Statement
+
+The skills in this repo reach `~/.claude/skills/` on a given machine only via the
+`sync-claude-skills` post-commit hook — which fires solely when *that machine* commits in
+the repo. On a machine that mostly *consumes* skills (clones the repo, rarely commits to
+it), there is no single command to pull what other people have pushed to `main` and
+re-sync. Today that means remembering the sequence by hand: `git checkout main`,
+`git pull`, then find and run `sync_claude_skills.py` with the right interpreter — and on a
+brand-new clone, also creating the `.venv` and installing the pre-commit hooks first. This
+has to work the same on macOS and on Windows (Git Bash), the two environments the repo
+already documents.
+
+## Solution
+
+A terminal command, `update-skills`, runnable from any directory, that performs the whole
+refresh in order:
+
+1. Refuse if the clone's working tree is dirty (print `git status`, exit non-zero) — never
+   stash or discard the user's work.
+2. Switch to `main` and fast-forward it to `origin/main` (`git pull --ff-only`; abort,
+   don't force, if history has diverged).
+3. First-run bootstrap, only when missing: create `.venv`, install `pre-commit` into it,
+   install the git hooks.
+4. Run `sync_claude_skills.py` to refresh `~/.claude/skills/`.
+
+Plus a one-time setup step, run once after cloning:
+
+```bash
+./install.sh
+```
+
+`install.sh` puts `update-skills` on the user's `PATH` by appending a marked block to their
+shell rc file that adds the repo's `bin/` directory to `PATH`. It is idempotent, tells the
+user how to activate the change in their current shell, and can be re-run if the clone
+moves.
+
+## User Stories
+
+1. As a developer on a machine that consumes skills, I want a single `update-skills`
+   command, so that I can pull the latest `main` and refresh `~/.claude/skills/` without
+   remembering the individual git and sync steps.
+2. As a developer who just cloned the repo, I want one setup instruction (`./install.sh`),
+   so that `update-skills` becomes available in my terminal without hand-editing my shell
+   configuration.
+3. As a developer whose first `update-skills` run is on a fresh clone, I want it to create
+   the `.venv` and install the pre-commit hooks automatically, so that one command covers
+   both first-run setup and the ongoing refresh.
+4. As a developer with work in progress in the clone, I want `update-skills` to refuse
+   while the tree is dirty, so that it never stashes, discards, or fast-forwards over my
+   uncommitted changes.
+5. As a developer whose local `main` has diverged from `origin/main`, I want the pull to
+   abort rather than force, so that no local commits are silently lost.
+6. As a developer on Windows using Git Bash, I want `update-skills` and `install.sh` to
+   behave the same as on macOS, so that the same repo works across the team's machines.
+7. As a maintainer, I want the two new shell scripts linted on every commit, so that
+   portability mistakes are caught before they land.
+
+## Implementation Decisions
+
+- **Two checked-in files plus config and docs:**
+  - `bin/update-skills` — the command. No file extension, so the command name is clean;
+    `bin/` holds only this one entry, so adding `bin/` to `PATH` shadows nothing.
+  - `install.sh` at the repo root — the one-time setup.
+- **`install.sh` behaviour:**
+  - Resolves its own directory as the repo root, so `./install.sh` or an absolute path both
+    work.
+  - Chooses the rc file from the login shell: `~/.zshrc` when `$SHELL` ends in `zsh`
+    (macOS default), otherwise `~/.bashrc` (Git Bash on Windows, Linux). If the chosen file
+    does not exist it is created.
+  - Appends a block delimited by marker comments
+    (`# >>> skills update-skills >>>` / `# <<< skills update-skills <<<`) containing
+    `export PATH="<repo>/bin:$PATH"`. Idempotent: if a block with those markers already
+    exists it is replaced (handles a moved clone), not duplicated.
+  - Prints that the current shell needs a new terminal or `source <rc-file>` to pick up the
+    change — a child process cannot mutate its parent shell's environment.
+  - If `<repo>/bin` is already on `PATH` and the marker block is already present and
+    correct, reports "already set up" and makes no edit.
+- **`bin/update-skills` behaviour:**
+  - Resolves the repo root from its own location (`dirname "$0"/..`), with a short symlink
+    resolution loop for safety; does not rely on `readlink -f` (absent/different on BSD and
+    some Git Bash builds). `cd`s to the repo root before any git command.
+  - Dirty-tree guard first: `test -n "$(git status --porcelain)"` → print `git status`,
+    exit 1, before touching git or the sync.
+  - `git checkout main` then `git pull --ff-only`. A non-fast-forward pull fails on its own;
+    the script surfaces the failure and exits non-zero. No `--force`, no reset.
+  - Interpreter resolution mirrors `.pre-commit-config.yaml`'s `sync-claude-skills` hook, in
+    the same order: `.venv/Scripts/python` (Windows venv) → `.venv/bin/python`
+    (macOS/Linux venv) → `python3` → `python`.
+  - Bootstrap runs only when needed: if no `.venv`, create it with the first system
+    interpreter found and `pip install pre-commit` into it; if the pre-commit hook is not
+    installed (`git rev-parse --git-path hooks/pre-commit` missing), run
+    `pre-commit install` from the venv. A second run finds both present and skips straight
+    to the sync.
+  - Final step: run `sync_claude_skills.py` with the resolved interpreter (the venv one
+    after bootstrap). The sync script is unchanged — it is standard-library only and already
+    walks the repo copying every `SKILL.md` directory to `~/.claude/skills/`.
+  - `set -euo pipefail`; every step echoes a one-line progress marker so a failure is
+    attributable.
+- **`main` is hardcoded** as the branch to track (declared once as a variable at the top of
+  the script) — matching the repo's actual default branch and the explicit request.
+- **Lint:** add the `shellcheck-py` hook to `.pre-commit-config.yaml` so `install.sh` and
+  `bin/update-skills` are checked on every commit. `.gitattributes` already forces LF on
+  `*.sh`; add `bin/update-skills` to that rule so the extensionless script keeps LF too.
+- **`context.md`:** add a short "Skill Distribution" subsection defining `update-skills`,
+  `install.sh`, and the existing `sync-claude-skills` hook as bounded terms.
+- **No ADR:** the change is a few small files and a hook line; reverting it is trivial and
+  needs no context to understand.
+
+## Testing Decisions
+
+- The repo has **no automated test harness** — verification across existing specs is
+  "review + `pre-commit-check`". Same here, with two layers:
+  - **Static:** the new `shellcheck` pre-commit hook lints both scripts on every commit;
+    `pre-commit-check` must pass clean.
+  - **Behavioural:** the Given-When-Then scenarios below are executed by hand on macOS and
+    recorded in the PR. Windows (Git Bash) is exercised on a best-effort basis by a
+    reviewer with access; the platform-specific surface is limited to the rc-file choice
+    and the interpreter-resolution order, both of which are read-path branches a reviewer
+    can confirm.
+- Good verification here checks **observable outcomes** — a line in the rc file, the branch
+  after a run, files under `~/.claude/skills/`, the exit code — not the script's internal
+  structure.
+- Scenarios:
+  1. *Fresh setup puts the command on PATH.* Given a clone whose `bin/` is not on `PATH`,
+     when `./install.sh` runs, then a single marker-delimited block adding `<repo>/bin` to
+     `PATH` is appended to the correct rc file, and the script prints how to activate it
+     now.
+  2. *Setup is idempotent.* Given `install.sh` has already run, when it runs again, then the
+     rc file still contains exactly one marker block and it is unchanged (or rewritten in
+     place if the clone moved), never duplicated.
+  3. *Refresh pulls and syncs.* Given `update-skills` is on `PATH` and the tree is clean,
+     when it runs from any directory, then the clone is on `main`, fast-forwarded to
+     `origin/main`, and `~/.claude/skills/` reflects the repo's current `SKILL.md`
+     directories.
+  4. *First run bootstraps.* Given a clone with no `.venv` and no installed pre-commit hook,
+     when `update-skills` runs, then `.venv` is created, `pre-commit` is installed into it,
+     the git hooks are installed, and the sync still completes; a second run skips the
+     bootstrap.
+  5. *Dirty tree is refused.* Given the clone has uncommitted changes, when `update-skills`
+     runs, then it prints `git status`, changes no git state and runs no sync, and exits
+     non-zero.
+  6. *Diverged `main` is refused.* Given local `main` has a commit not on `origin/main`,
+     when `update-skills` runs, then `git pull --ff-only` fails, the script reports it, and
+     exits non-zero without forcing or resetting.
+  7. *Interpreter resolution matches the hook.* Given a Windows-style `.venv/Scripts/python`
+     or a POSIX `.venv/bin/python`, when `update-skills` runs the sync, then it uses the
+     same interpreter the `sync-claude-skills` hook would, falling back to `python3` then
+     `python` when no venv exists.
+
+## Out of Scope
+
+- Changing `sync_claude_skills.py` itself (unchanged).
+- A native Windows entry point (`.cmd`/`.ps1`) or PowerShell support — Windows use is via
+  Git Bash, consistent with the repo's existing setup instructions.
+- Auto-`source`ing the rc file into the user's running shell — impossible from a child
+  process; the user opens a new terminal or sources it themselves.
+- Any dependency resolution beyond `pre-commit` (the sync itself needs none).
+- Adding a shell test framework (e.g. `bats`) — no prior art in the repo; `shellcheck`
+  plus the manual scenarios are the agreed bar.
+- Making `update-skills` work against a fork/upstream whose default branch is not `main`.
+
+## Further Notes
+
+- The post-commit `sync-claude-skills` hook stays as-is; `update-skills` complements it for
+  the consume-only workflow rather than replacing it.
+- `install.sh` writing to `~/.bashrc` on Git Bash follows the Git-for-Windows convention
+  where `~/.bash_profile` sources `~/.bashrc`; noted in the README setup section.

--- a/.agent-docs/specs/feature/update-skills-command.md
+++ b/.agent-docs/specs/feature/update-skills-command.md
@@ -88,8 +88,9 @@ moves.
   - `git checkout main` then `git pull --ff-only`. A non-fast-forward pull fails on its own;
     the script surfaces the failure and exits non-zero. No `--force`, no reset.
   - Interpreter resolution mirrors `.pre-commit-config.yaml`'s `sync-claude-skills` hook, in
-    the same order: `.venv/Scripts/python` (Windows venv) → `.venv/bin/python`
-    (macOS/Linux venv) → `python3` → `python`.
+    the same order: `.venv/Scripts/python` → `.venv/Scripts/python.exe` (Windows venv, the
+    latter as seen from Git Bash) → `.venv/bin/python` (macOS/Linux venv) → `python3` →
+    `python`. The two system interpreters are used only to create the venv.
   - Bootstrap runs only when needed: if no `.venv`, create it with the first system
     interpreter found and `pip install pre-commit` into it; if the pre-commit hook is not
     installed (`git rev-parse --git-path hooks/pre-commit` missing), run
@@ -146,10 +147,11 @@ moves.
   6. *Diverged `main` is refused.* Given local `main` has a commit not on `origin/main`,
      when `update-skills` runs, then `git pull --ff-only` fails, the script reports it, and
      exits non-zero without forcing or resetting.
-  7. *Interpreter resolution matches the hook.* Given a Windows-style `.venv/Scripts/python`
-     or a POSIX `.venv/bin/python`, when `update-skills` runs the sync, then it uses the
-     same interpreter the `sync-claude-skills` hook would, falling back to `python3` then
-     `python` when no venv exists.
+  7. *Interpreter resolution matches the hook.* Given a Windows-style
+     `.venv/Scripts/python` or `.venv/Scripts/python.exe` (Git Bash), or a POSIX
+     `.venv/bin/python`, when `update-skills` runs the sync, then it uses the same
+     interpreter the `sync-claude-skills` hook would, using `python3` then `python` only to
+     create the venv when none exists.
 
 ## Out of Scope
 

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.sh text eol=lf
+bin/update-skills text eol=lf

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,3 +1,4 @@
 {
-  "MD013": false
+  "MD013": false,
+  "MD024": { "siblings_only": true }
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
     hooks:
       - id: codespell
 
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+
   - repo: local
     hooks:
       - id: sync-claude-skills

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: sync-claude-skills
         name: Sync Claude skills to ~/.claude/skills
         language: system
-        entry: bash -c "if [ -f .venv/Scripts/python ]; then .venv/Scripts/python sync_claude_skills.py; elif [ -f .venv/bin/python ]; then .venv/bin/python sync_claude_skills.py; elif command -v python3 >/dev/null 2>&1; then python3 sync_claude_skills.py; else python sync_claude_skills.py; fi"
+        entry: bash -c "if [ -f .venv/Scripts/python ]; then .venv/Scripts/python sync_claude_skills.py; elif [ -f .venv/Scripts/python.exe ]; then .venv/Scripts/python.exe sync_claude_skills.py; elif [ -f .venv/bin/python ]; then .venv/bin/python sync_claude_skills.py; elif command -v python3 >/dev/null 2>&1; then python3 sync_claude_skills.py; else python sync_claude_skills.py; fi"
         stages: [post-commit]
         always_run: true
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,27 @@ A collection of Claude Code skills that sync automatically to `~/.claude/skills`
 
 ## Setup
 
+### Keeping skills in sync (`update-skills`)
+
+On a machine that just *uses* these skills, clone the repo and run once:
+
+```bash
+./install.sh
+```
+
+This adds `update-skills` to your `PATH` — via `~/.zshrc` for zsh (macOS default), or
+`~/.bashrc` otherwise (Git Bash on Windows, Linux). Open a new terminal or `source` that
+file, then run `update-skills` any time to fast-forward this clone to `main` and re-sync
+`~/.claude/skills`. It refuses to run if the clone has uncommitted changes.
+
+The first `update-skills` run also creates `.venv` and installs the pre-commit hooks, so on
+a consume-only machine this is the only setup you need — the rest of this section is for
+contributors.
+
+On Windows, run both `./install.sh` and `update-skills` from Git Bash (the shell the rest of
+this guide assumes); `install.sh` writes to `~/.bashrc`, which Git for Windows' `~/.bash_profile`
+sources.
+
 ### Prerequisites
 
 Install [pre-commit](https://pre-commit.com):
@@ -15,7 +36,7 @@ pre-commit install
 
 ### Python environment
 
-The `Sync Claude Skills` post-commit hook runs `sync_claude_skills.py` using the first PythPleon it finds, checked in this order:
+The `Sync Claude Skills` post-commit hook runs `sync_claude_skills.py` using the first Python it finds, checked in this order:
 
 1. `.venv/Scripts/python` (Windows venv)
 2. `.venv/bin/python` (macOS/Linux venv)

--- a/README.md
+++ b/README.md
@@ -36,12 +36,17 @@ pre-commit install
 
 ### Python environment
 
-The `Sync Claude Skills` post-commit hook runs `sync_claude_skills.py` using the first Python it finds, checked in this order:
+The `Sync Claude Skills` post-commit hook and the `update-skills` command both run
+`sync_claude_skills.py` using the first Python they find, checked in this order:
 
 1. `.venv/Scripts/python` (Windows venv)
-2. `.venv/bin/python` (macOS/Linux venv)
-3. System `python3`
-4. System `python`
+2. `.venv/Scripts/python.exe` (Windows venv, as seen from Git Bash)
+3. `.venv/bin/python` (macOS/Linux venv)
+4. System `python3`
+5. System `python`
+
+`update-skills` only uses the system interpreters (4–5) to *create* the `.venv`; it always
+runs `pip` and the sync against the venv.
 
 **macOS/Linux:**
 

--- a/address-copilot-comments/scripts/check-review-status.sh
+++ b/address-copilot-comments/scripts/check-review-status.sh
@@ -57,6 +57,7 @@ fi
 # on GitHub, and -F's type auto-detection would otherwise send it as a JSON number, which the
 # $owner/$repo: String! variables below would reject). -F sends $number as an actual number,
 # matching its Int! declaration.
+# shellcheck disable=SC2016  # $owner/$repo/$number are GraphQL variables, not shell — must stay literal
 THREAD_COUNT=$(gh api graphql -f query='
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {

--- a/bin/update-skills
+++ b/bin/update-skills
@@ -49,8 +49,9 @@ git checkout "$BRANCH"
 
 say "Fast-forwarding to origin/$BRANCH"
 if ! git pull --ff-only origin "$BRANCH"; then
-	echo "update-skills: origin/$BRANCH could not be fast-forwarded (history has diverged)." >&2
-	echo "Resolve it manually — update-skills will not force or reset." >&2
+	echo "update-skills: 'git pull --ff-only origin $BRANCH' failed — see the git output above for the reason." >&2
+	echo "If the histories have diverged, resolve it by hand; update-skills will not force or reset." >&2
+	echo "It could also be a network or auth problem reaching origin." >&2
 	exit 1
 fi
 

--- a/bin/update-skills
+++ b/bin/update-skills
@@ -48,7 +48,12 @@ if ! git pull --ff-only origin "$BRANCH"; then
 	exit 1
 fi
 
-# --- resolve a Python interpreter (mirrors .pre-commit-config.yaml) --------
+# --- resolve Python interpreters ----------------------------------------
+# Overall precedence matches .pre-commit-config.yaml's sync-claude-skills hook
+# (.venv/Scripts/python[.exe] -> .venv/bin/python -> python3 -> python), but the
+# two system candidates are only ever used to *create* the venv, never to run
+# pip or the sync — every install and the sync itself run against the venv, so
+# `pip install` can't leak into system/user site-packages.
 sys_py=""
 for candidate in python3 python; do
 	if command -v "$candidate" >/dev/null 2>&1; then
@@ -58,8 +63,7 @@ for candidate in python3 python; do
 done
 
 pick_venv_py() {
-	# Windows venvs first (Git Bash sees python.exe), then POSIX — same
-	# precedence as .pre-commit-config.yaml's sync-claude-skills hook.
+	# Windows venvs first (Git Bash sees python.exe), then POSIX.
 	for p in .venv/Scripts/python .venv/Scripts/python.exe .venv/bin/python; do
 		if [ -x "$p" ]; then
 			printf '%s' "$p"
@@ -78,23 +82,26 @@ if [ -z "$venv_py" ]; then
 	say "Creating .venv"
 	"$sys_py" -m venv .venv
 	venv_py="$(pick_venv_py)"
+	if [ -z "$venv_py" ]; then
+		echo "update-skills: created .venv but no interpreter appeared inside it." >&2
+		echo "Your platform's python venv package is probably missing — install it and re-run." >&2
+		echo "Refusing to continue against system Python (would install pre-commit globally)." >&2
+		exit 1
+	fi
 fi
-
-py="$venv_py"
-[ -n "$py" ] || py="$sys_py"
 
 hook_path="$(git rev-parse --git-path hooks/pre-commit)"
 if [ ! -e "$hook_path" ]; then
-	if ! "$py" -m pre_commit --version >/dev/null 2>&1; then
-		say "Installing pre-commit"
-		"$py" -m pip install --quiet pre-commit
+	if ! "$venv_py" -m pre_commit --version >/dev/null 2>&1; then
+		say "Installing pre-commit into .venv"
+		"$venv_py" -m pip install --quiet pre-commit
 	fi
 	say "Installing git hooks"
-	"$py" -m pre_commit install
+	"$venv_py" -m pre_commit install
 fi
 
 # --- sync --------------------------------------------------------------
 say "Syncing skills to ~/.claude/skills"
-"$py" sync_claude_skills.py
+"$venv_py" sync_claude_skills.py
 
 say "Done — ~/.claude/skills is up to date with origin/$BRANCH."

--- a/bin/update-skills
+++ b/bin/update-skills
@@ -25,9 +25,15 @@ while [ -h "$script" ]; do
 done
 bin_dir="$(cd -P "$(dirname "$script")" && pwd)"
 repo="$(cd -P "$bin_dir/.." && pwd)"
-cd "$repo"
 
 say() { printf '==> %s\n' "$1"; }
+die() { echo "update-skills: $1" >&2; exit 1; }
+
+# --- sanity: are we actually in this repo? ------------------------------
+# Guards against the script being copied out of bin/, or an unexpected $0.
+cd "$repo" || die "cannot enter repo root $repo"
+[ -f "$repo/sync_claude_skills.py" ] || die "$repo does not look like the skills repo (no sync_claude_skills.py) — run the copy that lives in the cloned repo's bin/."
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || die "$repo is not a git work tree."
 
 # --- guard: refuse on a dirty working tree --------------------------------
 if [ -n "$(git status --porcelain)" ]; then
@@ -73,20 +79,20 @@ pick_venv_py() {
 }
 
 # --- first-run bootstrap: .venv + pre-commit hooks ----------------------
+# runs_ok <interpreter> — true if it executes at all
+runs_ok() { [ -n "$1" ] && "$1" -c '' >/dev/null 2>&1; }
+
 venv_py="$(pick_venv_py)"
+if [ -n "$venv_py" ] && ! runs_ok "$venv_py"; then
+	die ".venv exists but its interpreter ($venv_py) won't run — delete .venv and re-run."
+fi
 if [ -z "$venv_py" ]; then
-	if [ -z "$sys_py" ]; then
-		echo "update-skills: no python3 or python on PATH; cannot create .venv." >&2
-		exit 1
-	fi
+	[ -n "$sys_py" ] || die "no python3 or python on PATH; cannot create .venv."
 	say "Creating .venv"
 	"$sys_py" -m venv .venv
 	venv_py="$(pick_venv_py)"
-	if [ -z "$venv_py" ]; then
-		echo "update-skills: created .venv but no interpreter appeared inside it." >&2
-		echo "Your platform's python venv package is probably missing — install it and re-run." >&2
-		echo "Refusing to continue against system Python (would install pre-commit globally)." >&2
-		exit 1
+	if ! runs_ok "$venv_py"; then
+		die "created .venv but its interpreter is missing or won't run — your platform's python venv package is probably absent; install it and re-run. (Refusing to fall back to system Python: that would install pre-commit globally.)"
 	fi
 fi
 

--- a/bin/update-skills
+++ b/bin/update-skills
@@ -42,7 +42,7 @@ say "Switching to $BRANCH"
 git checkout "$BRANCH"
 
 say "Fast-forwarding to origin/$BRANCH"
-if ! git pull --ff-only; then
+if ! git pull --ff-only origin "$BRANCH"; then
 	echo "update-skills: origin/$BRANCH could not be fast-forwarded (history has diverged)." >&2
 	echo "Resolve it manually — update-skills will not force or reset." >&2
 	exit 1
@@ -58,11 +58,14 @@ for candidate in python3 python; do
 done
 
 pick_venv_py() {
-	if [ -x .venv/Scripts/python ]; then
-		printf '%s' .venv/Scripts/python
-	elif [ -x .venv/bin/python ]; then
-		printf '%s' .venv/bin/python
-	fi
+	# Windows venvs first (Git Bash sees python.exe), then POSIX — same
+	# precedence as .pre-commit-config.yaml's sync-claude-skills hook.
+	for p in .venv/Scripts/python .venv/Scripts/python.exe .venv/bin/python; do
+		if [ -x "$p" ]; then
+			printf '%s' "$p"
+			return
+		fi
+	done
 }
 
 # --- first-run bootstrap: .venv + pre-commit hooks ----------------------

--- a/bin/update-skills
+++ b/bin/update-skills
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# update-skills — refresh ~/.claude/skills from this repo's main branch.
+#
+# Fast-forwards this clone to origin/main, bootstraps the local .venv and the
+# pre-commit hooks on first run, then runs sync_claude_skills.py. Safe to run
+# from any directory. Refuses to run if the working tree is dirty — it never
+# stashes, resets, or force-pulls.
+#
+# Works the same on macOS and on Windows (Git Bash).
+set -euo pipefail
+
+BRANCH="main"
+
+# --- resolve the repo root from this script's own location ------------------
+# Follow symlinks so it works when invoked directly, through a PATH entry
+# pointing at bin/, or via a symlink into bin/.
+script="${BASH_SOURCE[0]}"
+while [ -h "$script" ]; do
+	dir="$(cd -P "$(dirname "$script")" && pwd)"
+	script="$(readlink "$script")"
+	case "$script" in
+		/*) ;;
+		*) script="$dir/$script" ;;
+	esac
+done
+bin_dir="$(cd -P "$(dirname "$script")" && pwd)"
+repo="$(cd -P "$bin_dir/.." && pwd)"
+cd "$repo"
+
+say() { printf '==> %s\n' "$1"; }
+
+# --- guard: refuse on a dirty working tree --------------------------------
+if [ -n "$(git status --porcelain)" ]; then
+	echo "update-skills: working tree has uncommitted changes — aborting." >&2
+	echo >&2
+	git status >&2
+	exit 1
+fi
+
+# --- refresh the branch --------------------------------------------------
+say "Switching to $BRANCH"
+git checkout "$BRANCH"
+
+say "Fast-forwarding to origin/$BRANCH"
+if ! git pull --ff-only; then
+	echo "update-skills: origin/$BRANCH could not be fast-forwarded (history has diverged)." >&2
+	echo "Resolve it manually — update-skills will not force or reset." >&2
+	exit 1
+fi
+
+# --- resolve a Python interpreter (mirrors .pre-commit-config.yaml) --------
+sys_py=""
+for candidate in python3 python; do
+	if command -v "$candidate" >/dev/null 2>&1; then
+		sys_py="$candidate"
+		break
+	fi
+done
+
+pick_venv_py() {
+	if [ -x .venv/Scripts/python ]; then
+		printf '%s' .venv/Scripts/python
+	elif [ -x .venv/bin/python ]; then
+		printf '%s' .venv/bin/python
+	fi
+}
+
+# --- first-run bootstrap: .venv + pre-commit hooks ----------------------
+venv_py="$(pick_venv_py)"
+if [ -z "$venv_py" ]; then
+	if [ -z "$sys_py" ]; then
+		echo "update-skills: no python3 or python on PATH; cannot create .venv." >&2
+		exit 1
+	fi
+	say "Creating .venv"
+	"$sys_py" -m venv .venv
+	venv_py="$(pick_venv_py)"
+fi
+
+py="$venv_py"
+[ -n "$py" ] || py="$sys_py"
+
+hook_path="$(git rev-parse --git-path hooks/pre-commit)"
+if [ ! -e "$hook_path" ]; then
+	if ! "$py" -m pre_commit --version >/dev/null 2>&1; then
+		say "Installing pre-commit"
+		"$py" -m pip install --quiet pre-commit
+	fi
+	say "Installing git hooks"
+	"$py" -m pre_commit install
+fi
+
+# --- sync --------------------------------------------------------------
+say "Syncing skills to ~/.claude/skills"
+"$py" sync_claude_skills.py
+
+say "Done — ~/.claude/skills is up to date with origin/$BRANCH."

--- a/bin/update-skills
+++ b/bin/update-skills
@@ -96,14 +96,26 @@ if [ -z "$venv_py" ]; then
 	fi
 fi
 
-hook_path="$(git rev-parse --git-path hooks/pre-commit)"
-if [ ! -e "$hook_path" ]; then
-	if ! "$venv_py" -m pre_commit --version >/dev/null 2>&1; then
-		say "Installing pre-commit into .venv"
-		"$venv_py" -m pip install --quiet pre-commit
-	fi
+# hooks_ok — true only if BOTH hook types this repo configures
+# (default_install_hook_types in .pre-commit-config.yaml: pre-commit, post-commit)
+# are present and pre-commit-generated. Checking just hooks/pre-commit would let
+# a lone pre-commit hook mask a missing post-commit hook — and post-commit is
+# the one that runs sync_claude_skills.py.
+hooks_ok() {
+	local h p
+	for h in pre-commit post-commit; do
+		p="$(git rev-parse --git-path "hooks/$h")"
+		[ -f "$p" ] && grep -q 'pre-commit\.com' "$p" || return 1
+	done
+}
+
+if ! "$venv_py" -m pre_commit --version >/dev/null 2>&1; then
+	say "Installing pre-commit into .venv"
+	"$venv_py" -m pip install --quiet pre-commit
+fi
+if ! hooks_ok; then
 	say "Installing git hooks"
-	"$venv_py" -m pre_commit install
+	"$venv_py" -m pre_commit install >/dev/null
 fi
 
 # --- sync --------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# install.sh — one-time setup: put the `update-skills` command on your PATH.
+#
+# Adds this repo's bin/ directory to PATH via a marker-delimited block in your
+# shell rc file (~/.zshrc for zsh, ~/.bashrc otherwise — including Git Bash on
+# Windows). Idempotent: re-running replaces a stale block in place (e.g. after
+# moving the clone) rather than duplicating it.
+set -euo pipefail
+
+repo="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+bin_dir="$repo/bin"
+
+marker_start="# >>> skills update-skills >>>"
+marker_end="# <<< skills update-skills <<<"
+path_line="export PATH=\"$bin_dir:\$PATH\""
+
+# --- pick the rc file for the login shell ------------------------------
+case "${SHELL:-}" in
+	*zsh) rc="$HOME/.zshrc" ;;
+	*) rc="$HOME/.bashrc" ;;
+esac
+
+block="$marker_start
+# Added by skills/install.sh — puts the update-skills command on PATH.
+$path_line
+$marker_end"
+
+# --- already set up? -------------------------------------------------
+if [ -f "$rc" ] && grep -qF "$marker_start" "$rc"; then
+	if grep -qxF "$path_line" "$rc"; then
+		echo "update-skills is already set up in $rc — nothing to do."
+		echo "If it isn't on your PATH yet, open a new terminal or run: source $rc"
+		exit 0
+	fi
+	echo "Refreshing the update-skills block in $rc (clone path changed)."
+	remaining="$(awk -v s="$marker_start" -v e="$marker_end" '
+		$0 == s { skip = 1 }
+		!skip  { print }
+		$0 == e { skip = 0 }
+	' "$rc")"
+	if [ -n "$remaining" ]; then
+		printf '%s\n' "$remaining" > "$rc"
+	else
+		: > "$rc"
+	fi
+fi
+
+# --- append the block ----------------------------------------------
+touch "$rc"
+# separate from existing content with exactly one blank line
+if [ -s "$rc" ] && [ -n "$(tail -c1 "$rc" 2>/dev/null)" ]; then
+	printf '\n\n' >> "$rc"
+elif [ -s "$rc" ]; then
+	printf '\n' >> "$rc"
+fi
+printf '%s\n' "$block" >> "$rc"
+
+echo "Added update-skills to your PATH via $rc."
+case ":${PATH:-}:" in
+	*":$bin_dir:"*) echo "(this shell already has $bin_dir on PATH)" ;;
+	*) echo "Open a new terminal, or run: source $rc" ;;
+esac
+echo "Then run: update-skills"

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,9 @@
 #
 # Adds this repo's bin/ directory to PATH via a marker-delimited block in your
 # shell rc file (~/.zshrc for zsh, ~/.bashrc otherwise — including Git Bash on
-# Windows). Idempotent: re-running replaces a stale block in place (e.g. after
-# moving the clone) rather than duplicating it.
+# Windows). Idempotent: re-running drops any existing block(s) and appends one
+# current block at the end of the file, so a moved clone or a duplicate is
+# corrected without ever stacking blocks up.
 set -euo pipefail
 
 repo="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/install.sh
+++ b/install.sh
@@ -79,10 +79,18 @@ fi
 # --- append the block, separated from existing content by exactly one blank line ---
 touch "$rc"
 if [ -s "$rc" ]; then
-	# strip any trailing blank lines first, so the separator below is the only one
-	tmp="$rc.us-tmp.$$"
-	awk 'NF { for (i = 0; i < pending; i++) print ""; pending = 0; print; next }
-	     { pending++ }' "$rc" > "$tmp" && mv "$tmp" "$rc"
+	# strip any trailing blank lines first, so the separator below is the only one.
+	# mktemp (not "$rc.$$") avoids a predictable name / symlink footgun; same dir
+	# keeps the mv atomic.
+	tmp="$(mktemp "$(dirname "$rc")/.update-skills.XXXXXX")"
+	if awk 'NF { for (i = 0; i < pending; i++) print ""; pending = 0; print; next }
+	        { pending++ }' "$rc" > "$tmp"; then
+		mv "$tmp" "$rc"
+	else
+		rm -f "$tmp"
+		echo "install.sh: failed to normalise $rc — left unchanged." >&2
+		exit 1
+	fi
 	printf '\n' >> "$rc"
 fi
 printf '%s\n' "$block" >> "$rc"

--- a/install.sh
+++ b/install.sh
@@ -25,36 +25,45 @@ block="$marker_start
 $path_line
 $marker_end"
 
-# --- already set up? -------------------------------------------------
-# "Set up" means our own marker block exists AND carries the current path_line.
-# Matching path_line anywhere in the file would be fooled by a hand-added
-# identical export sitting next to a stale (old-clone) marker block.
+# --- inspect any existing marker block(s) --------------------------------
+# One nesting-aware pass over the rc file classifies the current state:
+#   MALFORMED <why>       markers nested, out of order, or unterminated
+#   OK blocks=<n> match=<0|1>   n well-formed blocks; match=1 iff some block
+#                              already carries the exact current path_line
+# "Already set up" (no edit) is ONLY blocks=1 match=1. Anything else — a stale
+# path, or duplicate blocks — is normalised to a single fresh block. A
+# MALFORMED file is left untouched: the removal pass could otherwise swallow
+# the user's real config below a broken marker.
 if [ -f "$rc" ] && grep -qF "$marker_start" "$rc"; then
-	# Refuse to touch the file if the block is malformed (start without a
-	# matching end, or vice versa): the removal awk below would otherwise treat
-	# everything after a lone start marker as "inside the block" and drop it.
-	starts="$(grep -cF "$marker_start" "$rc")"
-	ends="$(grep -cF "$marker_end" "$rc")"
-	if [ "$starts" != "$ends" ]; then
-		echo "install.sh: $rc has an unbalanced update-skills block ($starts start / $ends end marker(s))." >&2
-		echo "Fix or delete that block by hand, then re-run — refusing to edit and risk clobbering your shell config." >&2
-		exit 1
-	fi
-	current_block="$(awk -v s="$marker_start" -v e="$marker_end" '
-		$0 == s { inblock = 1 }
-		inblock { print }
-		$0 == e { inblock = 0 }
+	state="$(awk -v s="$marker_start" -v e="$marker_end" -v want="$path_line" '
+		$0 == s { if (depth) { done = 1; print "MALFORMED nested-start-marker"; exit } depth = 1; blocks++; next }
+		$0 == e { if (!depth) { done = 1; print "MALFORMED end-marker-before-start"; exit } depth = 0; next }
+		depth && $0 == want { match_found = 1 }
+		END {
+			if (done) { exit }
+			if (depth) { print "MALFORMED unterminated-block"; exit }
+			printf "OK blocks=%d match=%d\n", blocks, match_found
+		}
 	' "$rc")"
-	if printf '%s\n' "$current_block" | grep -qxF "$path_line"; then
-		echo "update-skills is already set up in $rc — nothing to do."
-		echo "If it isn't on your PATH yet, open a new terminal or run: source $rc"
-		exit 0
-	fi
-	echo "Refreshing the update-skills block in $rc (clone path changed)."
+
+	case "$state" in
+		MALFORMED*)
+			echo "install.sh: $rc has a broken update-skills block (${state#MALFORMED })." >&2
+			echo "Fix or delete that block by hand, then re-run — refusing to edit and risk clobbering your shell config." >&2
+			exit 1
+			;;
+		"OK blocks=1 match=1")
+			echo "update-skills is already set up in $rc — nothing to do."
+			echo "If it isn't on your PATH yet, open a new terminal or run: source $rc"
+			exit 0
+			;;
+	esac
+
+	echo "Refreshing the update-skills block in $rc."
 	remaining="$(awk -v s="$marker_start" -v e="$marker_end" '
-		$0 == s { skip = 1 }
+		$0 == s { skip = 1; next }
+		$0 == e { skip = 0; next }
 		!skip  { print }
-		$0 == e { skip = 0 }
 	' "$rc")"
 	if [ -n "$remaining" ]; then
 		printf '%s\n' "$remaining" > "$rc"

--- a/install.sh
+++ b/install.sh
@@ -30,6 +30,16 @@ $marker_end"
 # Matching path_line anywhere in the file would be fooled by a hand-added
 # identical export sitting next to a stale (old-clone) marker block.
 if [ -f "$rc" ] && grep -qF "$marker_start" "$rc"; then
+	# Refuse to touch the file if the block is malformed (start without a
+	# matching end, or vice versa): the removal awk below would otherwise treat
+	# everything after a lone start marker as "inside the block" and drop it.
+	starts="$(grep -cF "$marker_start" "$rc")"
+	ends="$(grep -cF "$marker_end" "$rc")"
+	if [ "$starts" != "$ends" ]; then
+		echo "install.sh: $rc has an unbalanced update-skills block ($starts start / $ends end marker(s))." >&2
+		echo "Fix or delete that block by hand, then re-run — refusing to edit and risk clobbering your shell config." >&2
+		exit 1
+	fi
 	current_block="$(awk -v s="$marker_start" -v e="$marker_end" '
 		$0 == s { inblock = 1 }
 		inblock { print }
@@ -53,12 +63,13 @@ if [ -f "$rc" ] && grep -qF "$marker_start" "$rc"; then
 	fi
 fi
 
-# --- append the block ----------------------------------------------
+# --- append the block, separated from existing content by exactly one blank line ---
 touch "$rc"
-# separate from existing content with exactly one blank line
-if [ -s "$rc" ] && [ -n "$(tail -c1 "$rc" 2>/dev/null)" ]; then
-	printf '\n\n' >> "$rc"
-elif [ -s "$rc" ]; then
+if [ -s "$rc" ]; then
+	# strip any trailing blank lines first, so the separator below is the only one
+	tmp="$rc.us-tmp.$$"
+	awk 'NF { for (i = 0; i < pending; i++) print ""; pending = 0; print; next }
+	     { pending++ }' "$rc" > "$tmp" && mv "$tmp" "$rc"
 	printf '\n' >> "$rc"
 fi
 printf '%s\n' "$block" >> "$rc"

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,9 @@ $path_line
 $marker_end"
 
 # --- inspect any existing marker block(s) --------------------------------
+# Trigger on EITHER marker: a lone end marker (from a half-deleted block) must
+# reach the validator and fail safely now, not be ignored so a fresh block is
+# appended and the next run bricks on end-before-start.
 # One nesting-aware pass over the rc file classifies the current state:
 #   MALFORMED <why>       markers nested, out of order, or unterminated
 #   OK blocks=<n> match=<0|1>   n well-formed blocks; match=1 iff some block
@@ -34,7 +37,7 @@ $marker_end"
 # path, or duplicate blocks — is normalised to a single fresh block. A
 # MALFORMED file is left untouched: the removal pass could otherwise swallow
 # the user's real config below a broken marker.
-if [ -f "$rc" ] && grep -qF "$marker_start" "$rc"; then
+if [ -f "$rc" ] && { grep -qF "$marker_start" "$rc" || grep -qF "$marker_end" "$rc"; }; then
 	state="$(awk -v s="$marker_start" -v e="$marker_end" -v want="$path_line" '
 		$0 == s { if (depth) { done = 1; print "MALFORMED nested-start-marker"; exit } depth = 1; blocks++; next }
 		$0 == e { if (!depth) { done = 1; print "MALFORMED end-marker-before-start"; exit } depth = 0; next }

--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,16 @@ $path_line
 $marker_end"
 
 # --- already set up? -------------------------------------------------
+# "Set up" means our own marker block exists AND carries the current path_line.
+# Matching path_line anywhere in the file would be fooled by a hand-added
+# identical export sitting next to a stale (old-clone) marker block.
 if [ -f "$rc" ] && grep -qF "$marker_start" "$rc"; then
-	if grep -qxF "$path_line" "$rc"; then
+	current_block="$(awk -v s="$marker_start" -v e="$marker_end" '
+		$0 == s { inblock = 1 }
+		inblock { print }
+		$0 == e { inblock = 0 }
+	' "$rc")"
+	if printf '%s\n' "$current_block" | grep -qxF "$path_line"; then
 		echo "update-skills is already set up in $rc — nothing to do."
 		echo "If it isn't on your PATH yet, open a new terminal or run: source $rc"
 		exit 0


### PR DESCRIPTION
Closes #56, closes #57.

## What

A terminal command, `update-skills`, that refreshes `~/.claude/skills` on a machine that consumes skills, plus a one-time `install.sh` that puts it on `PATH`.

- **`bin/update-skills`** (extensionless, runnable from any directory): refuses on a dirty working tree (prints `git status`, exits non-zero — never stashes/resets) → `git checkout main` + `git pull --ff-only` (aborts on divergence, never forces) → first-run bootstrap of `.venv` + pre-commit hooks *only when missing* → runs `sync_claude_skills.py`. Interpreter resolution mirrors `.pre-commit-config.yaml`: `.venv/Scripts/python` → `.venv/bin/python` → `python3` → `python`. Same behaviour on macOS and Windows (Git Bash).
- **`install.sh`**: appends a marker-delimited block adding `<repo>/bin` to `PATH` in the login shell's rc file (`~/.zshrc` for zsh, else `~/.bashrc`). Idempotent — a stale block (moved clone) is rewritten in place, never duplicated. Prints how to activate it in the current shell.
- **Supporting**: `shellcheck` pre-commit hook (`shellcheck-py`); `bin/update-skills` added to the `.gitattributes` LF rule; `MD024: siblings_only` in `.markdownlint.json` (the create-issues template repeats `### What to build` per slice); one-line `# shellcheck disable=SC2016` waiver on the pre-existing GraphQL helper where `$owner/$repo/$number` are GraphQL variables, not shell; README "Setup" section; `.agent-docs/context.md` "Skill Distribution" terms.

Spec: `.agent-docs/specs/feature/update-skills-command.md`.

## Test plan

No automated harness in this repo — verified by `pre-commit` (shellcheck clean on both scripts, both passes green) plus the spec's Given-When-Then scenarios run in an isolated bare-remote + clone harness with a fake `$HOME`:

| Scenario | Result |
|---|---|
| S1 fresh setup (zsh) appends one marker block to `~/.zshrc`; `.bashrc` untouched | pass |
| S1-bash non-zsh writes/creates `~/.bashrc` | pass |
| S2 re-run idempotent (file byte-identical); moved-clone stale block rewritten in place, still one block | pass |
| sourcing the rc actually puts `update-skills` on `PATH` | pass |
| S3 refresh from an unrelated dir, clean tree → on `main`, fast-forwarded, `~/.claude/skills` repopulated | pass (exit 0) |
| S4 first run creates `.venv`, installs pre-commit + both git hooks, completes sync; second run skips bootstrap | pass |
| S5 dirty tree → prints `git status`, no git/sync change, exit non-zero | pass |
| S6 diverged `main` → `git pull --ff-only` fails, script reports it, local HEAD unchanged, exit non-zero | pass |
| S7 interpreter resolution follows the hook order (venv first) | pass |

Manual Windows/Git Bash run not exercised here; platform-specific surface is limited to the rc-file choice and the interpreter-resolution order (both read-path branches).