### PR TITLE
Add change-hygiene review criteria from the update-skills retro

### DIFF
--- a/.agent-docs/issues/chore/review-criteria-change-hygiene.md
+++ b/.agent-docs/issues/chore/review-criteria-change-hygiene.md
@@ -1,0 +1,57 @@
+# Issues: chore/review-criteria-change-hygiene
+
+## Add change-hygiene review criteria to `code-review/REVIEW-CRITERIA.md`
+
+**GitHub**: #59
+
+**Blocked by**: None
+
+**User stories**: 1–7
+
+### What to build
+
+Fold seven generalised review lessons (from the PR #58 / `update-skills` retrospective) into
+`code-review/REVIEW-CRITERIA.md`, in the file's existing terse imperative style. The whole
+file is passed verbatim to the `code-review` Standards sub-agent.
+
+- **Code Correctness** — three new bullets:
+  - Destructive edits to files the change doesn't own (shell rc, another team's
+    config/schema, a user document): "structure not understood" must be a safe refusal that
+    leaves the file untouched, never a best-effort edit that can truncate/corrupt.
+  - A check that inspects one artefact when the thing being verified needs several (one of N
+    hooks, config keys, migrations).
+  - Code shelling out to external tools (`git`/`pip`/network/`venv`…) without guarding
+    foreseeable failures or attaching an actionable cause; error text asserting one cause
+    when several are possible.
+- **Code Quality** — one new bullet: a comment or doc claiming a stronger guarantee than the
+  code delivers ("exactly one", "in place", "atomic", "idempotent").
+- **Security and Performance** — two new bullets:
+  - An unsafe fallback: when the preferred resource is missing, doing something materially
+    riskier (global/system install, unpinned version, world-writable path) instead of
+    failing clearly.
+  - Predictable temp paths (`$f.$$`, fixed `/tmp` names, PID suffixes) that should be
+    `mktemp`; temp files not cleaned up on failure.
+- **Documentation** — rewrite the existing "Stale rationale sweep" bullet so it covers both
+  design-rationale/invariant comments *and* a changed value/order/enumeration that is
+  restated in prose elsewhere (README, config comment, spec, another doc): every
+  restatement must move in the same change. One bullet, not two.
+
+No new section. Fowler smell baseline and the top-of-file preamble unchanged.
+`code-review/SKILL.md` unchanged.
+
+### Acceptance criteria
+
+- [ ] `code-review/REVIEW-CRITERIA.md` contains all seven points: 3 in Code Correctness, 1
+      in Code Quality, 2 in Security and Performance, and the rewritten Documentation
+      bullet.
+- [ ] The Documentation "Stale rationale sweep" bullet is rewritten (not duplicated) and
+      still covers everything the original did, plus restated values/orders/enumerations.
+- [ ] Every new bullet is generic — no `update-skills`, shell-rc, or PR-#58 specifics — and
+      matches the length/voice of the other bullets in its section.
+- [ ] The Fowler smell baseline section and the two-rule preamble are byte-unchanged.
+- [ ] `code-review/SKILL.md` is unchanged.
+- [ ] Cross-check recorded: each of the 15 retrospective findings maps to at least one
+      bullet (existing or new) that would now flag it.
+- [ ] `pre-commit-check` passes.
+
+---

--- a/.agent-docs/issues/chore/review-criteria-change-hygiene.md
+++ b/.agent-docs/issues/chore/review-criteria-change-hygiene.md
@@ -1,5 +1,7 @@
 # Issues: chore/review-criteria-change-hygiene
 
+> Work complete — PR ready to merge.
+
 ## Add change-hygiene review criteria to `code-review/REVIEW-CRITERIA.md`
 
 **GitHub**: #59
@@ -41,17 +43,17 @@ No new section. Fowler smell baseline and the top-of-file preamble unchanged.
 
 ### Acceptance criteria
 
-- [ ] `code-review/REVIEW-CRITERIA.md` contains all seven points: 3 in Code Correctness, 1
+- [x] `code-review/REVIEW-CRITERIA.md` contains all seven points: 3 in Code Correctness, 1
       in Code Quality, 2 in Security and Performance, and the rewritten Documentation
       bullet.
-- [ ] The Documentation "Stale rationale sweep" bullet is rewritten (not duplicated) and
+- [x] The Documentation "Stale rationale sweep" bullet is rewritten (not duplicated) and
       still covers everything the original did, plus restated values/orders/enumerations.
-- [ ] Every new bullet is generic — no `update-skills`, shell-rc, or PR-#58 specifics — and
+- [x] Every new bullet is generic — no `update-skills`, shell-rc, or PR-#58 specifics — and
       matches the length/voice of the other bullets in its section.
-- [ ] The Fowler smell baseline section and the two-rule preamble are byte-unchanged.
-- [ ] `code-review/SKILL.md` is unchanged.
-- [ ] Cross-check recorded: each of the 15 retrospective findings maps to at least one
+- [x] The Fowler smell baseline section and the two-rule preamble are byte-unchanged.
+- [x] `code-review/SKILL.md` is unchanged.
+- [x] Cross-check recorded: each of the 15 retrospective findings maps to at least one
       bullet (existing or new) that would now flag it.
-- [ ] `pre-commit-check` passes.
+- [x] `pre-commit-check` passes.
 
 ---

--- a/.agent-docs/specs/chore/review-criteria-change-hygiene.md
+++ b/.agent-docs/specs/chore/review-criteria-change-hygiene.md
@@ -1,0 +1,106 @@
+# Generalise `update-skills` Review Lessons into `code-review` Criteria
+
+## Problem Statement
+
+The `update-skills` PR (#58) went through nine Copilot review rounds and fifteen
+findings. A retrospective (`copilot-fixes.md`, kept in scratch) showed the findings
+clustered into a handful of *general* review lessons — none of which
+`code-review/REVIEW-CRITERIA.md` currently states, so the `code-review` skill's Standards
+sub-agent would not have caught them on that PR and will not catch the same class of issue
+on the next one. The lessons are not shell- or `update-skills`-specific; they apply to any
+change that edits files it doesn't own, shells out to external tools, or restates a value in
+prose.
+
+## Solution
+
+Add the generalised lessons to `code-review/REVIEW-CRITERIA.md` as new review points, folded
+into the existing sections and phrased in the file's existing terse, imperative house style
+(the whole file is passed verbatim to the Standards sub-agent). One existing bullet is
+broadened rather than duplicated. No new section; the Fowler smell baseline is untouched.
+
+## User Stories
+
+1. As a reviewer running `/code-review`, I want the Standards sub-agent told to flag
+   best-effort edits to files the change does not own (shell rc files, another team's
+   config or schema, a user's document), so that a diff which can silently truncate or
+   corrupt such a file is caught as a blocking finding rather than read as "looks
+   reasonable".
+2. As a reviewer, I want the sub-agent told to flag an unsafe fallback — code that, when its
+   preferred resource is missing, does something materially riskier (global/system install,
+   unpinned version, world-writable path) instead of failing with a clear message.
+3. As a reviewer, I want the sub-agent told to flag a "spot check" that inspects one
+   artefact when the thing being verified needs several (one of N hooks, one of N config
+   keys, one of N migrations).
+4. As a reviewer, I want the sub-agent told to flag code that shells out to
+   `git`/`pip`/network/`venv` (etc.) without guarding foreseeable failures or attaching an
+   actionable cause, and to flag error text that asserts a single cause when several are
+   possible.
+5. As a reviewer, I want the sub-agent told to flag predictable temp paths (`$f.$$`, fixed
+   `/tmp` names, PID suffixes) that should be `mktemp`, and temp files not cleaned up on
+   failure.
+6. As a reviewer, I want the sub-agent told to flag a comment or doc that claims a stronger
+   guarantee than the code delivers ("exactly one", "in place", "atomic", "idempotent") —
+   either the code tightens or the claim is corrected.
+7. As a reviewer, I want the existing "stale rationale sweep" broadened so it also covers a
+   diff that changes a value, order, or enumeration which is *restated in prose* elsewhere
+   (README, config comment, spec, another doc) — every restatement must move in the same
+   change.
+
+## Implementation Decisions
+
+- Single file changed: `code-review/REVIEW-CRITERIA.md`. It is the sole source read by
+  `code-review/SKILL.md` Step 4 and passed verbatim to the Standards sub-agent — no mirror
+  to keep in sync.
+- Placement (folded into existing sections, no new section):
+  - **Code Correctness** — three new bullets: destructive edits to non-owned files (story
+    1); spot-check vs multi-part requirement (story 3); unguarded external-command failure
+    and single-cause error text (story 4).
+  - **Code Quality** — one new bullet: comment/doc guarantee stronger than the code delivers
+    (story 6).
+  - **Security and Performance** — two new bullets: unsafe fallback to a riskier action
+    (story 2); predictable temp paths / missing temp cleanup (story 5).
+  - **Documentation** — the existing "Stale rationale sweep" bullet is rewritten to cover
+    both design-rationale/invariant comments *and* restated values/orders/enumerations
+    (story 7). Not a second bullet.
+- Each new bullet follows the file's established form: a bold lead-in label, then an
+  imperative "flag …" / "check for …" instruction, one concrete example, kept to one or two
+  sentences. Consistent with the other bullets in each target section (which are prose
+  instructions, not the "→ fix" form used only in the Fowler list).
+- The two rule bindings at the top of the file ("The repo overrides", "Always a judgement
+  call", "Documented-standard breaches may be blocking; smells are always advisory") already
+  govern the new bullets — they are documented standards once added, so the sub-agent may
+  mark them blocking. No change to that preamble.
+- No ADR: this is additive review guidance in one markdown file; reverting is a one-file
+  diff and needs no context to understand.
+- Out of the diff: `.agent-docs/agent.md` (behavioural standards for *doing* work, a
+  separate concern from *reviewing* it) and `check-review-status.sh` (the review-body-prose
+  gap is its own follow-up).
+
+## Testing Decisions
+
+- No code seam — this is a guidance document. Consistent with prior doc-only changes in
+  this repo (e.g. `chore/sed-rename-caution`, `chore/stale-rationale-review-check`),
+  verification is:
+  - **Review**: each new bullet reads as a general heuristic (no `update-skills`/shell
+    specifics leaking in); it sits in the right section; it matches the surrounding bullets'
+    length and voice; the rewritten Documentation bullet still covers everything the
+    original did.
+  - **`pre-commit-check`**: markdownlint (and the repo's other hooks) pass on the file.
+- A light cross-check: map each of findings 1–15 in `copilot-fixes.md` to at least one
+  bullet (existing or new) that would now flag it, to confirm coverage and no gaps.
+
+## Out of Scope
+
+- Any change to `code-review/SKILL.md` itself (the workflow is unchanged; only the criteria
+  it feeds the sub-agent grow).
+- `.agent-docs/agent.md` and other skills.
+- The `check-review-status.sh` review-body-prose gap (follow-up issue, tracked separately).
+- Re-running the `update-skills` review against the new criteria.
+- Any new tooling or automated lint for these criteria — they are sub-agent guidance, human/
+  model judgement as with every other bullet in the file.
+
+## Further Notes
+
+Source material is `copilot-fixes.md` (session scratch, not committed): a per-round log of
+all fifteen findings plus an "Insights" section. Candidate criteria were labelled A–G during
+the grill; the mapping is A→story 1, B→2, C→3, D→4, E→5, F→6, G→7.

--- a/code-review/REVIEW-CRITERIA.md
+++ b/code-review/REVIEW-CRITERIA.md
@@ -31,6 +31,9 @@ Each smell: _what it is_ → _how to fix_:
 - **Acceptance Criteria**: step through each criterion and find the lines that satisfy it. If you cannot locate them, raise a blocking finding — code looking reasonable is insufficient.
 - **Edge cases**: look for missed edge cases (empty inputs, unhandled nulls, integer overflow, timezone mismatches, concurrent calls to the same endpoint).
 - **Error handling**: code must not swallow errors silently. Check for bare exceptions or missing propagation. Equally, check for uncaught exceptions that crash execution.
+- **Unguarded external commands**: when code shells out to `git`, a package manager, a network call, or toolchain/`venv` setup, check it guards the foreseeable failures — missing remote or auth, no network, wrong working directory, absent tool, half-built environment — and surfaces a cause the caller can act on rather than letting the raw downstream error escape. Flag an error message that names one cause ("history has diverged") when the same failure has several.
+- **Edits to files the change does not own**: when the diff parses and rewrites a file owned by the user or another system (a shell rc file, another team's config or schema, a file a different service generates), a structure it does not recognise must make it stop and leave the file untouched — never a best-effort edit. Flag any such parser that can truncate, reorder, or drop unrelated content when its assumptions do not hold.
+- **Partial checks for compound state**: flag a readiness or "already done" check that inspects one artefact when the state it gates has several parts — one of N git hooks, one of N config keys, one of N migrations, one file of a set written together. It must enumerate every part the operation needs.
 - **Async and concurrency safety**: verify logic is async-safe, uses approved libraries, and synchronous I/O is not blocking an event loop.
 - **Backwards compatibility**: check for breaking changes to response/request shapes or database column renames/removals. If other services need companion PRs, flag this explicitly.
 
@@ -44,6 +47,7 @@ Each smell: _what it is_ → _how to fix_:
 - **Circular imports**: check for circular imports, particularly in FastAPI and FastMCP, that are papered over with local imports inside functions.
 - **Mutation and I/O hygiene**: functions must not mutate their arguments. `__init__` must not perform I/O. Default arguments must not be mutable.
 - **Observability**: new code paths must have required logging and tests and meet existing observability non-functional requirements.
+- **Claims that outrun the code**: flag a comment, docstring, or doc line promising a stronger guarantee than the code delivers — "exactly one", "in place", "atomic", "idempotent", "always", "never". Resolve by tightening the code or correcting the claim.
 
 ---
 
@@ -60,6 +64,8 @@ If screenshots are included in the PR, review them against all acceptance criter
 - **Input sanitisation**: confirm inputs are appropriately sanitised, particularly anything from a request that flows into a query or LLM prompt.
 - **Dependencies**: review new dependencies — confirm they are necessary, actively maintained, and pinned. New packages that pull in large transitive dependency trees may introduce supply-chain risk.
 - **Performance bottlenecks**: flag infinite loops, database locks, large objects unnecessarily loaded into memory, and regexes compiled on every call.
+- **Unsafe fallback**: flag code that, when its preferred resource is missing, silently does something materially riskier instead of failing — installing into system/global scope when a virtualenv is absent, using an unpinned version when the pinned one is unavailable, writing to a world-writable or predictable path when a private one cannot be created. Failing with a clear message is usually the safer default.
+- **Predictable temp paths**: flag temp files or directories named from a fixed string, the PID (`$$`), or another guessable pattern instead of `mktemp` or the language's secure equivalent — they collide across concurrent runs and enable symlink attacks — and flag temp files left behind on the error path.
 
 ---
 
@@ -75,4 +81,4 @@ If screenshots are included in the PR, review them against all acceptance criter
 
 - **READMEs and runbooks**: check that READMEs, runbooks, wikis, and architecture docs are not outdated because of this PR. Authors must document their changes.
 - **Environment variables and configuration**: new environment variables or configuration values must be documented.
-- **Stale rationale sweep**: if the diff changes or removes a design-rationale or invariant comment (why something works a certain way, not what it does), search the repo for other copies of that rationale — restated in a class comment, an inline comment, a test comment, or a spec doc — since these are often paraphrased rather than repeated verbatim, and flag any left contradicting the new code.
+- **Restated-fact sweep**: when the diff changes or removes something that is stated in more than one place, find the other copies and flag any left contradicting the new code. Two kinds: (a) a design-rationale or invariant comment — why something works a certain way, not what it does — paraphrased in a class comment, an inline comment, a test comment, or a spec; (b) a concrete value, order, or enumeration — a fallback sequence, a set of supported types, a default, a threshold — also written out in a README, a config comment, a spec, or another doc. Both are usually reworded rather than repeated verbatim, so match on meaning.


### PR DESCRIPTION
Closes #59.

## What

PR #58 (`update-skills`) took nine Copilot rounds and fifteen findings. A retrospective showed they cluster into a handful of **general** review lessons that `code-review/REVIEW-CRITERIA.md` didn't state — so the `code-review` Standards sub-agent wouldn't have caught them, and won't catch the same class next time. This folds them in.

Single behavioural file changed: `code-review/REVIEW-CRITERIA.md` (passed verbatim to the Standards sub-agent). `code-review/SKILL.md`, the Fowler smell baseline, and the two-rule preamble are untouched. No new section.

- **Code Correctness** — 3 new bullets:
  - *Unguarded external commands* — shelling out to git / pip / network / venv without guarding foreseeable failures or attaching an actionable cause; single-cause error text ("history has diverged") when the failure has several.
  - *Edits to files the change does not own* — parsing/rewriting a shell rc file, another team's config/schema, etc.; an unrecognised structure must stop and leave the file untouched, never a best-effort edit that can truncate/reorder/drop content.
  - *Partial checks for compound state* — a readiness / "already done" check inspecting one artefact when the state has several parts (one of N hooks/keys/migrations).
- **Code Quality** — 1 new bullet:
  - *Claims that outrun the code* — a comment/doc promising "exactly one", "in place", "atomic", "idempotent", "always/never" that the code doesn't deliver.
- **Security and Performance** — 2 new bullets:
  - *Unsafe fallback* — when the preferred resource is missing, doing something materially riskier (system/global install, unpinned version, world-writable path) instead of failing clearly.
  - *Predictable temp paths* — fixed names / PID / guessable patterns instead of `mktemp`; temp files left on the error path.
- **Documentation** — the `Stale rationale sweep` bullet is **rewritten** (not duplicated) as `Restated-fact sweep`: still covers rationale/invariant comments, now also a changed value/order/enumeration restated in a README, config comment, spec, or other doc.

Spec: `.agent-docs/specs/chore/review-criteria-change-hygiene.md`.

## Finding to bullet cross-check (AC)

Each of the 15 retrospective findings maps to at least one bullet that would now flag it:

| # | Finding | Bullet |
|---|---------|--------|
| 1 | "already set up" matched PATH line anywhere | Edits to files the change does not own; Partial checks for compound state |
| 2 | unbalanced marker block -> truncation | Edits to files the change does not own |
| 3 | "exactly one blank line" comment inaccurate | Claims that outrun the code |
| 4 | venv interpreter mismatch; imprecise pull target | Restated-fact sweep; Unguarded external commands |
| 5 | count-only validation still truncatable; duplicates | Edits to files the change does not own |
| 6 | fall back to system Python -> global install | Unsafe fallback |
| 7 | lone end marker bypassed validator | Edits to files the change does not own; Partial checks for compound state |
| 8 | wrong repo root -> cryptic git error | Unguarded external commands |
| 9 | broken venv -> cryptic pip failure | Unguarded external commands |
| 10 | lone pre-commit hook masked missing post-commit | Partial checks for compound state |
| 11 | interpreter order: script vs hook vs README | Restated-fact sweep |
| 12 | "rewritten in place" wording vs behaviour | Claims that outrun the code |
| 13 | spec + issues kept the old interpreter order | Restated-fact sweep |
| 14 | predictable temp file name | Predictable temp paths |
| 15 | pull failure message assumed divergence | Unguarded external commands |

## Test plan

Doc-only; no code seam (consistent with prior doc changes like `chore/sed-rename-caution`). `pre-commit` clean on changed-files and full-repo passes (markdownlint et al.). Reviewed that each bullet is generic, correctly placed, and matches its section's voice; the rewritten Documentation bullet still covers everything the original did.
