### PR TITLE
Add .agent-docs/review.md review-criteria feedback loop

### DIFF
--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -85,7 +85,7 @@ _Avoid_: hidden comment, collapsed comment, filtered finding
 ### Agent Docs
 
 **Agent docs**:
-The `.agent-docs/` directory containing agent-facing documentation for a repository: `agent.md`, `context.md`, `specs/`, `issues/`, and `adr/`.
+The `.agent-docs/` directory containing agent-facing documentation for a repository: `agent.md`, `context.md`, `review.md`, `specs/`, `issues/`, and `adr/`.
 _Avoid_: agent documentation, agent directory, .agent-docs folder
 
 **Context** (agent-docs sense):
@@ -103,6 +103,10 @@ _Avoid_: task, ticket, story (except in the GitHub Issues sense)
 **ADR** (Architecture Decision Record):
 A record in `.agent-docs/adr/` documenting a significant design choice and its rationale. Named with a zero-padded numeric prefix (e.g. `0001-decision-name.md`).
 _Avoid_: decision log, design decision
+
+**Review criteria** (`review.md`):
+The `.agent-docs/review.md` file holding review criteria a repository has accumulated from its own Copilot review rounds. `init-agent-docs` bootstraps it from a template; `address-copilot-comments` appends a generalised criterion for each Copilot finding that resulted in a code change (push-backs are never recorded); `code-review` feeds it to its Standards sub-agent as documented repo standards.
+_Avoid_: review notes, lessons file, review log
 
 ### Design and Implementation Process
 

--- a/.agent-docs/issues/feature/review-md-feedback-loop.md
+++ b/.agent-docs/issues/feature/review-md-feedback-loop.md
@@ -1,5 +1,7 @@
 # Issues: feature/review-md-feedback-loop
 
+> Work complete — PR ready to merge.
+
 ## 1. `.agent-docs/review.md` + `init-agent-docs` bootstrap
 
 **GitHub**: #61
@@ -30,18 +32,18 @@ Introduce the `.agent-docs/review.md` file and have `init-agent-docs` create it.
 
 ### Acceptance criteria
 
-- [ ] `init-agent-docs/REVIEW-TEMPLATE.md` exists with the header + `## Criteria` +
+- [x] `init-agent-docs/REVIEW-TEMPLATE.md` exists with the header + `## Criteria` +
       `_None yet._`.
-- [ ] `init-agent-docs` Step 6b is defined in SKILL.md (steps list) and REFERENCE.md with
+- [x] `init-agent-docs` Step 6b is defined in SKILL.md (steps list) and REFERENCE.md with
       the check → skip / write-verbatim shape, matching the `agent.md` steps' style.
-- [ ] Re-running `init-agent-docs` when `.agent-docs/review.md` already exists is a no-op
+- [x] Re-running `init-agent-docs` when `.agent-docs/review.md` already exists is a no-op
       that reports "already exists — skipping".
-- [ ] `init-agent-docs` frontmatter `description`, intro sentence, and all three REFERENCE.md
+- [x] `init-agent-docs` frontmatter `description`, intro sentence, and all three REFERENCE.md
       Step 10 summary examples mention `.agent-docs/review.md`.
-- [ ] Steps 7–10 and their cross-references are not renumbered.
-- [ ] This repo has `.agent-docs/review.md` (template, `_None yet._`) and a `review.md`
+- [x] Steps 7–10 and their cross-references are not renumbered.
+- [x] This repo has `.agent-docs/review.md` (template, `_None yet._`) and a `review.md`
       entry in `.agent-docs/context.md`.
-- [ ] `pre-commit-check` passes.
+- [x] `pre-commit-check` passes.
 
 ---
 
@@ -79,15 +81,15 @@ Step 8 of `address-copilot-comments`.
 
 ### Acceptance criteria
 
-- [ ] Step 7b is in the SKILL.md loop diagram and has a `## Step 7b` section; REFERENCE.md
+- [x] Step 7b is in the SKILL.md loop diagram and has a `## Step 7b` section; REFERENCE.md
       has the "Distil review criteria" detail.
-- [ ] The guard is explicit: exempt PR or zero fixes → no write, skip to Step 8.
-- [ ] The step text states that only Fixed findings are recorded and push-backs
+- [x] The guard is explicit: exempt PR or zero fixes → no write, skip to Step 8.
+- [x] The step text states that only Fixed findings are recorded and push-backs
       (`Ignored.`) are never written.
-- [ ] The dedup rule (against `.agent-docs/review.md` only) and the "replace `_None yet._`"
+- [x] The dedup rule (against `.agent-docs/review.md` only) and the "replace `_None yet._`"
       behaviour are specified.
-- [ ] The commit is a standalone commit to the PR branch with the specified message shape.
-- [ ] `pre-commit-check` passes.
+- [x] The commit is a standalone commit to the PR branch with the specified message shape.
+- [x] `pre-commit-check` passes.
 
 ---
 
@@ -116,14 +118,14 @@ Step 8 of `address-copilot-comments`.
 
 ### Acceptance criteria
 
-- [ ] `code-review/SKILL.md` Step 4 reads `.agent-docs/review.md` when present and passes it
+- [x] `code-review/SKILL.md` Step 4 reads `.agent-docs/review.md` when present and passes it
       to the Standards sub-agent as documented standards.
-- [ ] When `.agent-docs/review.md` is absent, the Standards sub-agent prompt is unchanged
+- [x] When `.agent-docs/review.md` is absent, the Standards sub-agent prompt is unchanged
       from today.
-- [ ] `REVIEW-CRITERIA.md`, the Fowler baseline, and the rest of `code-review/SKILL.md` are
+- [x] `REVIEW-CRITERIA.md`, the Fowler baseline, and the rest of `code-review/SKILL.md` are
       untouched.
-- [ ] Consistency check recorded: file name / path / header / "fixes only" wording match
+- [x] Consistency check recorded: file name / path / header / "fixes only" wording match
       across all three skills (restated-fact sweep applied to this change).
-- [ ] `pre-commit-check` passes.
+- [x] `pre-commit-check` passes.
 
 ---

--- a/.agent-docs/issues/feature/review-md-feedback-loop.md
+++ b/.agent-docs/issues/feature/review-md-feedback-loop.md
@@ -1,0 +1,129 @@
+# Issues: feature/review-md-feedback-loop
+
+## 1. `.agent-docs/review.md` + `init-agent-docs` bootstrap
+
+**GitHub**: #61
+
+**Blocked by**: None
+
+**User stories**: 1, 7
+
+### What to build
+
+Introduce the `.agent-docs/review.md` file and have `init-agent-docs` create it.
+
+- New `init-agent-docs/REVIEW-TEMPLATE.md`: an explanatory header (what the file is; that
+  `address-copilot-comments` maintains it — fixes only, never push-backs; that `code-review`
+  consumes it as documented standards; that entries can be pruned or promoted into
+  `REVIEW-CRITERIA.md` by hand) followed by `## Criteria` and a `_None yet._` empty state.
+- New `init-agent-docs` **Step 6b — Bootstrap `review.md`**, after Step 6, before Step 7: if
+  `.agent-docs/review.md` exists → report "already exists — skipping" and continue;
+  else write `REVIEW-TEMPLATE.md` verbatim, report "Created `.agent-docs/review.md`"; on
+  write failure report and continue to Step 7. No search-elsewhere and no review/improve
+  sub-path.
+- Update `init-agent-docs/SKILL.md` (`## Steps` list, frontmatter `description`, intro
+  sentence) and `init-agent-docs/REFERENCE.md` (new `## Step 6b` section; Step 6 hand-offs
+  to Step 7 become hand-offs to Step 6b; all three Step 10 summary examples gain a
+  `review.md` line).
+- Create this repo's `.agent-docs/review.md` from the template (`_None yet._`).
+- Add a `review.md` term to this repo's `.agent-docs/context.md` (Agent Docs section).
+
+### Acceptance criteria
+
+- [ ] `init-agent-docs/REVIEW-TEMPLATE.md` exists with the header + `## Criteria` +
+      `_None yet._`.
+- [ ] `init-agent-docs` Step 6b is defined in SKILL.md (steps list) and REFERENCE.md with
+      the check → skip / write-verbatim shape, matching the `agent.md` steps' style.
+- [ ] Re-running `init-agent-docs` when `.agent-docs/review.md` already exists is a no-op
+      that reports "already exists — skipping".
+- [ ] `init-agent-docs` frontmatter `description`, intro sentence, and all three REFERENCE.md
+      Step 10 summary examples mention `.agent-docs/review.md`.
+- [ ] Steps 7–10 and their cross-references are not renumbered.
+- [ ] This repo has `.agent-docs/review.md` (template, `_None yet._`) and a `review.md`
+      entry in `.agent-docs/context.md`.
+- [ ] `pre-commit-check` passes.
+
+---
+
+## 2. `address-copilot-comments` Step 7b — distil review criteria
+
+**GitHub**: #62
+
+**Blocked by**: #61
+
+**User stories**: 2, 3, 4
+
+### What to build
+
+New **Step 7b — Distil review criteria into `.agent-docs/review.md`**, between Step 7 and
+Step 8 of `address-copilot-comments`.
+
+- Guard: run only if `review_round` was set at Step 2b **and** ≥1 Fix was applied at any
+  Step 4 across the whole invocation; otherwise skip to Step 8.
+- Input: every finding this invocation whose Step 4 decision was **Fix** — real threads
+  (replied "Fixed.") and suppressed entries (recorded "Fixed." in a Step 4d comment).
+  Push-backs excluded.
+- Generalise each fixed finding into one criterion: strip file/line/identifier/value down to
+  the class of mistake; phrase as a bold-label + imperative rule in `REVIEW-CRITERIA.md`'s
+  voice; tag `(PR #<this PR>)`. Findings that generalise alike collapse to one entry.
+- Dedup against the target repo's existing `.agent-docs/review.md` only (match on meaning);
+  skip candidates already covered. Do not read `REVIEW-CRITERIA.md`.
+- If `.agent-docs/review.md` is absent, create it from the same header the `init-agent-docs`
+  template uses, then append. Replace a lone `_None yet._` rather than appending after it.
+- Commit on its own to the PR branch:
+  `git commit -m "docs: record N review criteria from Copilot review"` → push.
+- `address-copilot-comments/SKILL.md`: add `Step 7b` to the "Loop at a glance" diagram and a
+  `## Step 7b` section. `address-copilot-comments/REFERENCE.md`: add a "Distil review
+  criteria" section (how to generalise, the dedup rule, the first-creation header, the
+  commit message).
+
+### Acceptance criteria
+
+- [ ] Step 7b is in the SKILL.md loop diagram and has a `## Step 7b` section; REFERENCE.md
+      has the "Distil review criteria" detail.
+- [ ] The guard is explicit: exempt PR or zero fixes → no write, skip to Step 8.
+- [ ] The step text states that only Fixed findings are recorded and push-backs
+      (`Ignored.`) are never written.
+- [ ] The dedup rule (against `.agent-docs/review.md` only) and the "replace `_None yet._`"
+      behaviour are specified.
+- [ ] The commit is a standalone commit to the PR branch with the specified message shape.
+- [ ] `pre-commit-check` passes.
+
+---
+
+## 3. `code-review` reads `.agent-docs/review.md`
+
+**GitHub**: #63
+
+**Blocked by**: #61
+
+**User stories**: 5, 6
+
+### What to build
+
+`code-review` Step 4 also consumes the target repo's `.agent-docs/review.md`.
+
+- Step 4: "Read `REVIEW-CRITERIA.md` in full" → "…in full, and `.agent-docs/review.md` from
+  the target repo if it exists."
+- Step 4 Standards sub-agent prompt: the "complete contents of REVIEW-CRITERIA.md" bullet
+  gains "…and, if present, the target repo's `.agent-docs/review.md` (repo-specific criteria
+  accumulated from past Copilot reviews — treat its entries as documented standards, same as
+  REVIEW-CRITERIA.md)".
+- No other `code-review` change. Absent file → prompt byte-identical to today.
+- Cross-skill consistency: the file name, path, header wording, and the "fixes only, no
+  push-backs" description must read identically across `init-agent-docs`'s template,
+  `address-copilot-comments`'s REFERENCE.md, and this Step 4 text.
+
+### Acceptance criteria
+
+- [ ] `code-review/SKILL.md` Step 4 reads `.agent-docs/review.md` when present and passes it
+      to the Standards sub-agent as documented standards.
+- [ ] When `.agent-docs/review.md` is absent, the Standards sub-agent prompt is unchanged
+      from today.
+- [ ] `REVIEW-CRITERIA.md`, the Fowler baseline, and the rest of `code-review/SKILL.md` are
+      untouched.
+- [ ] Consistency check recorded: file name / path / header / "fixes only" wording match
+      across all three skills (restated-fact sweep applied to this change).
+- [ ] `pre-commit-check` passes.
+
+---

--- a/.agent-docs/review.md
+++ b/.agent-docs/review.md
@@ -17,4 +17,7 @@ from — for example:
 
 ## Criteria
 
-_None yet._
+- **Incomplete cross-reference**: when a change adds a fresh statement of a fact that is
+  defined canonically elsewhere (a rule, a constraint, an enumeration), it must carry the
+  same qualifiers as the canonical version — a summary that silently drops a caveat reads as
+  a contradiction between the two places. (PR #64)

--- a/.agent-docs/review.md
+++ b/.agent-docs/review.md
@@ -1,0 +1,20 @@
+# Review Criteria (repo-specific)
+
+Review criteria this repository has accumulated from its own Copilot review rounds.
+
+- The `address-copilot-comments` skill appends a generalised, one-line criterion here for
+  every Copilot finding on a PR that resulted in a code change. Findings that were pushed
+  back on ("Ignored.") are never recorded — this file only holds criteria the team accepted
+  by changing code.
+- The `code-review` skill feeds this file to its Standards sub-agent alongside the skill's
+  own `REVIEW-CRITERIA.md`, and treats the entries here as documented repo standards (a
+  breach may be blocking).
+- Prune stale entries, and promote durable ones into a shared criteria file, by hand.
+
+Each entry is a bold label plus a one-line imperative rule, tagged with the PR it came
+from — for example:
+`- **Partial checks for compound state**: flag a readiness check that inspects one artefact when the state it gates has several parts. (PR #58)`
+
+## Criteria
+
+_None yet._

--- a/.agent-docs/specs/feature/review-md-feedback-loop.md
+++ b/.agent-docs/specs/feature/review-md-feedback-loop.md
@@ -1,0 +1,195 @@
+# `.agent-docs/review.md` — a per-repo review-criteria feedback loop
+
+## Problem Statement
+
+The `code-review` skill feeds its Standards sub-agent a single fixed file,
+`code-review/REVIEW-CRITERIA.md`, shipped with the skill. Everything a repo learns from its
+own Copilot review rounds — the recurring classes of mistake Copilot keeps catching — is
+lost once the PR merges, unless a human notices the pattern and hand-edits
+`REVIEW-CRITERIA.md` (as was just done for the `update-skills` PR after a manual
+retrospective). There is no mechanism for a repo to accumulate its own review criteria, and
+no automatic path from "Copilot found this and we fixed it" to "the next review checks for
+this".
+
+## Solution
+
+A new per-repo file, `.agent-docs/review.md`, holding review criteria accumulated from that
+repository's own Copilot reviews. Three skills cooperate:
+
+1. **`init-agent-docs`** bootstraps `.agent-docs/review.md` from a template when it does not
+   exist — the same verbatim-template pattern it uses for `agent.md`.
+2. **`address-copilot-comments`**, once its Copilot loop is clean, distils every finding
+   that resulted in a code change into a generalised one-line criterion and appends it to
+   `.agent-docs/review.md`. Push-backs (findings replied to with "Ignored.") are never
+   recorded — only things that changed the code.
+3. **`code-review`** reads `.agent-docs/review.md` (when present in the target repo) and
+   passes it to its Standards sub-agent alongside `REVIEW-CRITERIA.md`, treating its entries
+   as documented repo standards.
+
+The net effect: a class of mistake Copilot catches on one PR is on the review checklist for
+the next PR in that repo, without a human retrospective in the loop.
+
+## User Stories
+
+1. As a maintainer running any implementation workflow, I want `init-agent-docs` to create
+   `.agent-docs/review.md` if it is missing, so that the file the other two skills depend on
+   exists without a manual step, and re-running the skill is a safe no-op when it is already
+   present.
+2. As an author finishing an `address-copilot-comments` loop, I want each Copilot finding I
+   *fixed* (a real thread or a suppressed entry, across every round of that loop) turned
+   into a generalised review criterion and appended to `.agent-docs/review.md`, so the repo
+   accumulates its own review knowledge.
+3. As that same author, I want findings I *pushed back on* ("Ignored.") to leave no trace in
+   `.agent-docs/review.md`, so the file only ever contains criteria the team actually
+   accepted by changing code.
+4. As that author, I want a candidate criterion that merely restates something already in
+   `.agent-docs/review.md` to be skipped, so the file does not fill with near-duplicates
+   over many PRs.
+5. As a reviewer running `/code-review` in a repo that has a `.agent-docs/review.md`, I want
+   the Standards sub-agent to receive that file's criteria as documented standards (blocking
+   when breached, same status as `REVIEW-CRITERIA.md`), so accumulated lessons are actually
+   enforced on the next review.
+6. As a reviewer running `/code-review` in a repo with no `.agent-docs/review.md`, I want the
+   skill to behave exactly as before, so the feature is additive and safe for repos that
+   have never run `init-agent-docs`.
+7. As a maintainer of this skills repo, I want its own `.agent-docs/review.md` created from
+   the template in this change, so the repo dogfoods the loop and `init-agent-docs`'s
+   "already exists" path is exercised here.
+
+## Implementation Decisions
+
+### File: `.agent-docs/review.md`
+
+- Format: a short explanatory header, then a single `## Criteria` section holding a flat
+  markdown list. Empty state is an explicit `_None yet._` line.
+- Each entry: a bold label + an imperative one-line rule in the same voice as
+  `REVIEW-CRITERIA.md`'s bullets, ending with a `(PR #N)` source tag. Example:
+  `- **Partial checks for compound state**: a readiness check that inspects one artefact when the state has several parts. (PR #58)`
+- The header states what the file is, that `address-copilot-comments` maintains it (fixes
+  only, no push-backs), that `code-review` consumes it as documented standards, and that
+  entries can be pruned or promoted into the shared `REVIEW-CRITERIA.md` by hand.
+- Lives at `.agent-docs/review.md`; it is agent-facing repo documentation, a sibling of
+  `agent.md` / `context.md`, not an ADR or spec.
+
+### `init-agent-docs`
+
+- New template file `init-agent-docs/REVIEW-TEMPLATE.md`, alongside `AGENT-TEMPLATE.md`,
+  holding the header + empty `## Criteria` section verbatim.
+- New step **6b — Bootstrap `review.md`**, placed after Step 6 (context.md) and before Step
+  7 (ADR migration). A lettered sub-step is used deliberately so Steps 7–10 and their
+  cross-references are not renumbered.
+  - If `.agent-docs/review.md` exists → report "`.agent-docs/review.md` already exists —
+    skipping." and continue to Step 7.
+  - Else → ensure `.agent-docs/` exists, write `REVIEW-TEMPLATE.md` verbatim to
+    `.agent-docs/review.md`, report "Created `.agent-docs/review.md`." On write failure,
+    report and continue to Step 7 (consistent with the context.md failure handling — a
+    missing `review.md` is not fatal to the rest of the bootstrap).
+  - Unlike `context.md`, there is no "search elsewhere and move" and no
+    "review/improve existing" sub-path — the file is machine-maintained; if it exists,
+    leave it untouched.
+- Updated surfaces: the SKILL.md `## Steps` list (new item 6b), the SKILL.md frontmatter
+  `description` (mention `.agent-docs/review.md`), the SKILL.md intro sentence, REFERENCE.md
+  (new `## Step 6b` section; the Step 6 "continue to Step 7" hand-offs become "continue to
+  Step 6b"), and all three Step 10 summary examples in REFERENCE.md (add a `review.md`
+  line).
+
+### `address-copilot-comments`
+
+- New step **7b — Distil review criteria into `.agent-docs/review.md`**, between Step 7 and
+  Step 8.
+- Guarded: run 7b only if `review_round` was set at Step 2b (an exempt PR never learned
+  anything) **and** at least one Fix was applied at any Step 4 across the whole invocation.
+  Otherwise skip straight to Step 8.
+- Inputs: the set of findings across every round of this invocation whose Step 4 decision
+  was **Fix** — both real threads (replied "Fixed.") and suppressed entries (recorded as
+  "Fixed." in a Step 4d PR comment). Push-backs are excluded.
+- For each fixed finding, write one generalised criterion: strip the specifics (file name,
+  line number, the concrete identifier or value) down to the *class* of mistake, phrased as
+  a reusable rule in `REVIEW-CRITERIA.md`'s bold-label + imperative voice, tagged
+  `(PR #<this PR>)`. Multiple findings that generalise to the same rule collapse to one
+  entry.
+- Dedup: before appending, compare each candidate against the entries already in the target
+  repo's `.agent-docs/review.md` (match on meaning, not text). Skip any candidate already
+  covered. Dedup is only against `.agent-docs/review.md` — the skill does not read
+  `code-review/REVIEW-CRITERIA.md` (it may not be present in the target repo, and mild
+  overlap is acceptable).
+- If `.agent-docs/review.md` does not exist, create it from the same header the
+  `init-agent-docs` template uses, then append. Replace a lone `_None yet._` line rather
+  than appending after it.
+- Commit the file change to the PR branch on its own:
+  `git add .agent-docs/review.md` → `git commit -m "docs: record N review criteria from Copilot review"` → push.
+  This lands in the same PR whose review produced the criteria.
+- REFERENCE.md gains a "Distil review criteria" section: how to generalise a finding, the
+  dedup rule, the file header for first creation, and the commit message.
+- The SKILL.md "Loop at a glance" diagram gains a `Step 7b` line; Step 8's wording is
+  otherwise unchanged.
+
+### `code-review`
+
+- Step 4: "Read `REVIEW-CRITERIA.md` in full" becomes "Read `REVIEW-CRITERIA.md` in full,
+  and `.agent-docs/review.md` from the target repo if it exists."
+- Step 4 Standards sub-agent prompt: the "complete contents of REVIEW-CRITERIA.md" bullet
+  gains "…and, if present, the contents of the target repo's `.agent-docs/review.md`
+  (repo-specific criteria accumulated from past Copilot reviews — treat its entries as
+  documented standards, same as REVIEW-CRITERIA.md)."
+- No other `code-review` change. When `.agent-docs/review.md` is absent the prompt is
+  byte-identical to today.
+
+### This repo
+
+- Create `.agent-docs/review.md` from the new template (starts at `_None yet._` — the seven
+  criteria added for the `update-skills` retro already live in `REVIEW-CRITERIA.md` and are
+  not duplicated here).
+- Add a `review.md` term to `.agent-docs/context.md` under the Agent Docs section.
+- No change to `.agent-docs/agent.md` (behavioural standards for doing work, not review
+  context).
+
+### No ADR
+
+Three coordinated skill edits plus a new doc file; reverting is a contained diff and needs
+no rationale record.
+
+## Testing Decisions
+
+- No code seam — three skills defined in markdown, one new markdown template, one new repo
+  doc. Verification, consistent with prior skill changes in this repo
+  (`chore/review-criteria-change-hygiene`, `chore/sed-rename-caution`):
+  - **Review** each edited skill end-to-end against its own step logic: `init-agent-docs`
+    Step 6b has the same shape as the `agent.md` steps (check → skip / write verbatim);
+    `address-copilot-comments` Step 7b's guard, generalise, dedup, and commit are
+    unambiguous and reference REFERENCE.md for detail; `code-review` Step 4 degrades to
+    today's behaviour when the file is absent.
+  - **Trace three scenarios** on paper against the new step text:
+    1. `init-agent-docs` on a repo with no `.agent-docs/review.md` → file created from
+       template; re-run → "already exists — skipping".
+    2. `address-copilot-comments` finishing a loop where round 1 fixed two findings and
+       round 2 pushed back on one → exactly the two fixed findings are generalised, deduped,
+       and committed; the push-back leaves no entry; an exempt PR writes nothing.
+    3. `code-review` Step 4 in a repo with a populated `.agent-docs/review.md` → its
+       criteria appear in the Standards sub-agent prompt as documented standards; in a repo
+       without the file → prompt unchanged.
+  - **`pre-commit-check`**: markdownlint and the other hooks pass on every changed file.
+  - **Cross-skill consistency check**: the file name, path, header wording, and "fixes only,
+    no push-backs" rule are stated identically in `init-agent-docs`'s template,
+    `address-copilot-comments`'s REFERENCE.md, and `code-review`'s Step 4 — apply the
+    "restated-fact sweep" criterion to this very change.
+
+## Out of Scope
+
+- Auto-pruning, ranking, or promoting `.agent-docs/review.md` entries into
+  `REVIEW-CRITERIA.md` — a human does that.
+- Recording findings from `code-review`'s own Standards/Spec sub-agents — only Copilot
+  findings, per the request.
+- Per-round writes — one synthesis pass at the end of the `address-copilot-comments` loop.
+- `address-copilot-comments` reading or reconciling against `code-review/REVIEW-CRITERIA.md`.
+- Any change to `agent.md`, `pr-cleanup`, `bdd`, or the `implement` workflow.
+- Back-filling `.agent-docs/review.md` in this repo with the `update-skills` retro criteria
+  (already in `REVIEW-CRITERIA.md`).
+
+## Further Notes
+
+- `.agent-docs/review.md` is deliberately shaped like `REVIEW-CRITERIA.md`'s bullets so a
+  maintainer can lift a stabilised entry straight into the shared file.
+- `address-copilot-comments` Step 4b already runs `code-review` Steps 1–5 mid-loop; that
+  path only *reads* `.agent-docs/review.md`, and Step 7b only *writes* it after the loop is
+  clean, so there is no write-during-read hazard.

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -299,6 +299,43 @@ gh api repos/{owner}/{repo}/pulls/{number} --jq '.node_id'
 
 ---
 
+## Distil review criteria (Step 7b)
+
+### What generalising looks like
+
+A fixed finding names a specific mistake in a specific place. The criterion is the reusable
+shape of it. Strip, in order: the file path, the line number, the concrete identifier or
+literal value, and the specific tool or command — keep the failure mode and the check that
+catches it. Phrase every entry as a bold label + imperative rule matching the bullets in the
+`code-review` skill's `REVIEW-CRITERIA.md`, ending with `(PR #<number>)`.
+
+| Fixed finding (specific) | Criterion (general) |
+|---|---|
+| `install.sh` checked `hooks/pre-commit` only and missed a needed `hooks/post-commit` | `- **Partial checks for compound state**: flag a readiness check that inspects one artefact when the state it gates has several parts. (PR #58)` |
+| A `git pull` error message asserted "history has diverged" when a network failure hits the same path | `- **Single-cause error text**: flag an error message that names one cause when the same failure has several. (PR #58)` |
+
+### Dedupe
+
+Compare each candidate against the entries already in the target repo's
+`.agent-docs/review.md`, matching on meaning rather than wording, and skip any a current
+entry already covers. Do not read the `code-review` skill's `REVIEW-CRITERIA.md` — it may be
+absent in the target repo, and a little overlap between the two files is acceptable.
+
+### Writing the file
+
+- **File exists**: append the surviving criteria to the end of its `## Criteria` list. If
+  that list holds only the placeholder `_None yet._`, replace that line with the first
+  criterion rather than leaving it above the list.
+- **File does not exist** (the target repo never ran `init-agent-docs`): create
+  `.agent-docs/review.md` using the header from the `init-agent-docs` skill's
+  `REVIEW-TEMPLATE.md` (its sibling skill directory — do not paste a copy of that header
+  here), then add the criteria under `## Criteria`.
+- Commit only that file, on its own commit, message
+  `docs: record <N> review criteria from Copilot review` where `<N>` is the count actually
+  added. If dedupe removed every candidate, make no commit.
+
+---
+
 ## Staging rules
 
 | Situation | Command |
@@ -310,12 +347,12 @@ gh api repos/{owner}/{repo}/pulls/{number} --jq '.node_id'
 
 ## Loop termination conditions
 
-The loop (Steps 3–7) never starts at all if Step 2b judges the diff exempt — docs-only, config-only, or trivial. No review requested, no poll, no `review_round` set. PR is ready to merge.
+The loop (Steps 3–7) never starts at all if Step 2b judges the diff exempt — docs-only, config-only, or trivial. No review requested, no poll, no `review_round` set. Step 7b is also skipped (nothing was reviewed). PR is ready to merge.
 
 Otherwise, the loop is complete when **any** of these conditions is met:
 
-1. **All push-backs in a round** — no code changes were made. Threads are already resolved after Step 4c, and any suppressed comments are already acknowledged via the PR-level comment posted in Step 4d. Skip Steps 5–7; do not re-trigger Copilot. PR is ready to merge.
-2. **Max reviews reached** — `review_round >= 2` at Step 6. Do not re-trigger. PR is ready to merge.
-3. **Clean review or poll exhausted** — the Step 3 poll (or Step 7 re-poll) ends with zero unresolved threads and zero suppressed comments. Either a new Copilot review was detected with no comments (exits immediately to Step 8), or 10 attempts elapsed with no new review (falls through to Step 8).
+1. **All push-backs in a round** — no code changes were made this round. Threads are already resolved after Step 4c, and any suppressed comments are already acknowledged via the PR-level comment posted in Step 4d. Skip Steps 5–7 and do not re-trigger Copilot, then go to Step 7b.
+2. **Max reviews reached** — `review_round >= 2` at Step 6. Do not re-trigger; go to Step 7b.
+3. **Clean review or poll exhausted** — the Step 3 poll (or Step 7 re-poll) ends with zero unresolved threads and zero suppressed comments. Either a new Copilot review was detected with no comments, or 10 attempts elapsed with no new review. Go to Step 7b.
 
-In all cases the PR is considered clean and ready to merge.
+In every non-exempt case, Step 7b runs next — it records criteria only if at least one Fix was applied at some point this invocation, otherwise it is a no-op — and then the PR is ready to merge.

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -317,8 +317,8 @@ catches it. Phrase every entry as a bold label + imperative rule matching the bu
 ### Dedupe
 
 Compare each candidate against the entries already in the target repo's
-`.agent-docs/review.md`, matching on meaning rather than wording, and skip any a current
-entry already covers. Do not read the `code-review` skill's `REVIEW-CRITERIA.md` — it may be
+`.agent-docs/review.md`, matching on meaning rather than wording, and skip any that a
+current entry already covers. Do not read the `code-review` skill's `REVIEW-CRITERIA.md` — it may be
 absent in the target repo, and a little overlap between the two files is acceptable.
 
 ### Writing the file

--- a/address-copilot-comments/REFERENCE.md
+++ b/address-copilot-comments/REFERENCE.md
@@ -325,7 +325,8 @@ absent in the target repo, and a little overlap between the two files is accepta
 
 - **File exists**: append the surviving criteria to the end of its `## Criteria` list. If
   that list holds only the placeholder `_None yet._`, replace that line with the first
-  criterion rather than leaving it above the list.
+  criterion rather than leaving it above the list. If the file has been hand-edited and has
+  no `## Criteria` heading, add one at the end of the file, then append under it.
 - **File does not exist** (the target repo never ran `init-agent-docs`): create
   `.agent-docs/review.md` using the header from the `init-agent-docs` skill's
   `REVIEW-TEMPLATE.md` (its sibling skill directory — do not paste a copy of that header

--- a/address-copilot-comments/SKILL.md
+++ b/address-copilot-comments/SKILL.md
@@ -21,19 +21,21 @@ Step 2b Read PR diff (`gh pr diff`); review-required?
 Step 3  Record baseline Copilot review ID; poll every 60s:
         thread count > 0? ─────────────────────────────────────────► Step 4
         suppressed comments > 0 in latest review body? ─────────────► Step 4
-        both 0 + new Copilot review (IDs differ)? ───────────────────► Step 8 (reviewed clean)
+        both 0 + new Copilot review (IDs differ)? ───────────────────► Step 7b (reviewed clean)
         Poll exhausted? one final pass: threads > 0 or suppressed > 0? ► Step 4
-                        final pass: both 0, no new review? ──────────► Step 8
+                        final pass: both 0, no new review? ──────────► Step 7b
 Step 4  For each unresolved thread and each suppressed-comment entry: decide fix or push-back; apply code changes
 Step 4b Run code-review (Steps 1–5 only; skip code-review Step 6) to validate changes
 Step 4c Reply to each thread ("Fixed." / "Ignored.") → resolve thread immediately
 Step 4d Suppressed comments this round? ──Yes──► post one PR comment summarizing fix/ignore outcomes
-        All push-backs (threads + suppressed)? ──Yes──► Step 8 (skip Steps 5–7)
+        All push-backs (threads + suppressed)? ──Yes──► Step 7b (skip Steps 5–7)
 Step 5  Execute pre-commit-checks or .git/hooks/pre-commit (if any) → commit → push
 Step 6  review_round < 2? ──Yes──► review_round++; re-trigger Copilot → Step 7
-                          ──No ──► Step 8 (max 2 reviews; do not re-trigger)
+                          ──No ──► Step 7b (max 2 reviews; do not re-trigger)
 Step 7  Re-capture baseline; poll as in Step 3:
-        threads or suppressed comments? ──► Step 4 | clean or exhausted? ──► Step 8
+        threads or suppressed comments? ──► Step 4 | clean or exhausted? ──► Step 7b
+Step 7b Not exempt and ≥1 Fix applied this invocation? ──► generalise each fixed finding,
+        dedupe against .agent-docs/review.md, append, commit + push. Else ──► Step 8
 Step 8  Report PR link — PR is ready to merge
 ```
 
@@ -85,7 +87,7 @@ Both the thread-count check and the suppressed-comments check (a round can have 
 
 Before polling, capture the latest Copilot review ID as a baseline by calling the script once with no baseline argument (empty if no review exists yet; if this call already reports something actionable, skip straight to Step 4).
 
-Poll every 60 seconds, max 10 attempts, calling the script again each time: an actionable result exits to Step 4; a clean result (a new review with nothing to address) goes to Step 8 immediately; a failed `gh api` call is reported distinctly and must not be treated as "wait and retry"; otherwise wait and repeat.
+Poll every 60 seconds, max 10 attempts, calling the script again each time: an actionable result exits to Step 4; a clean result (a new review with nothing to address) goes to Step 7b immediately; a failed `gh api` call is reported distinctly and must not be treated as "wait and retry"; otherwise wait and repeat.
 
 After 10 attempts with no new clean review, call the script one final time following the same branching. See the status-check script section in [REFERENCE.md](REFERENCE.md) for the full command and output contract.
 
@@ -111,7 +113,7 @@ Reply to each **thread** ("Fixed. ..." or "Ignored. ...") and immediately resolv
 
 If any suppressed-comment entries were found in Step 3/7 this round, post a single PR-level comment summarizing the fix/ignore outcome for every one of them — see the Address Each Comment and Suppressed Entry section in [REFERENCE.md](REFERENCE.md) for the `gh pr comment` command. Post this regardless of whether this round's decisions (threads and suppressed comments together) were all push-backs — it's the only record of a suppressed comment's outcome, since it has no per-comment reply target. Skip this step entirely if there were no suppressed comments this round.
 
-All push-backs across both threads and suppressed comments, and zero files modified → skip to Step 8 (skip Steps 5–7). At least one fix → continue to Step 5.
+All push-backs across both threads and suppressed comments, and zero files modified → skip to Step 7b (skip Steps 5–7). At least one fix → continue to Step 5.
 
 ## Step 5 — Commit and push
 
@@ -119,11 +121,48 @@ Stage files explicitly (`git add <file1> <file2> ...`), commit with `"address Co
 
 ## Step 6 — Re-trigger Copilot (if within limit)
 
-If `review_round >= 2`, skip to Step 8. Otherwise increment to 2 and re-trigger via `gh pr edit {number} --add-reviewer @copilot`. See the Re-trigger Copilot Review section in [REFERENCE.md](REFERENCE.md) if that command fails.
+If `review_round >= 2`, skip to Step 7b. Otherwise increment to 2 and re-trigger via `gh pr edit {number} --add-reviewer @copilot`. See the Re-trigger Copilot Review section in [REFERENCE.md](REFERENCE.md) if that command fails.
 
 ## Step 7 — Check for new threads and suppressed comments
 
-Re-capture the baseline Copilot review ID, then poll as in Step 3. New unresolved threads or suppressed comments → return to Step 4. Neither (or clean review detected) → continue to Step 8.
+Re-capture the baseline Copilot review ID, then poll as in Step 3. New unresolved threads or suppressed comments → return to Step 4. Neither (or clean review detected) → continue to Step 7b.
+
+## Step 7b — Distil review criteria into `.agent-docs/review.md`
+
+Turn what Copilot caught on this PR into repo review criteria the `code-review` skill will
+apply to the next one.
+
+**Guard.** Run this step only if `review_round` was set at Step 2b (an exempt PR triggered
+no review, so there is nothing to learn) **and** at least one Step 4 decision across the
+whole invocation — any round — was **Fix**. Otherwise skip to Step 8.
+
+**Collect.** Take every finding this invocation whose decision was Fix: real threads you
+replied to with "Fixed.", and suppressed entries recorded as "Fixed." in a Step 4d PR
+comment. Exclude every push-back ("Ignored.") — `.agent-docs/review.md` records only
+criteria the team accepted by changing code.
+
+**Generalise.** For each fixed finding, write one criterion: drop the specifics — the file
+name, the line number, the concrete identifier or literal value — and keep the *class* of
+mistake, phrased as a bold-label + imperative rule in the voice of the `code-review` skill's
+`REVIEW-CRITERIA.md` bullets, ending with `(PR #<this PR number>)`. Two findings that
+generalise to the same rule become one entry.
+
+**Dedupe.** Read the target repo's existing `.agent-docs/review.md` (only that file — not
+the `code-review` skill's `REVIEW-CRITERIA.md`) and drop any candidate whose meaning an
+entry there already covers.
+
+**Write and commit.** See the Distil Review Criteria section in [REFERENCE.md](REFERENCE.md)
+for the append rules and the header to use when the file must be created. Then commit the
+file on its own:
+
+```bash
+git add .agent-docs/review.md
+git commit -m "docs: record <N> review criteria from Copilot review"
+git push
+```
+
+`<N>` is the number of criteria actually added. If dedupe removed every candidate, make no
+commit. Continue to Step 8.
 
 ## Step 8 — Report completion
 

--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -56,7 +56,7 @@ If the user supplied an explicit commit, branch, or tag, use that instead. A bad
 
 ## Step 4 — Spawn parallel review agents
 
-Read [REVIEW-CRITERIA.md](REVIEW-CRITERIA.md) in full, and the target repo's `.agent-docs/review.md` if it exists (repo-specific criteria accumulated by `address-copilot-comments` from past Copilot reviews). Capture the diff:
+Read [REVIEW-CRITERIA.md](REVIEW-CRITERIA.md) in full, and the target repo's `.agent-docs/review.md` if it exists (repo-specific criteria `address-copilot-comments` distils from past Copilot findings that resulted in a code change — push-backs are never recorded). Capture the diff:
 
 ```bash
 git diff origin/$BASE...HEAD
@@ -68,7 +68,7 @@ Send a **single message** with two `Agent` tool calls (type: `general-purpose`):
 **Standards sub-agent prompt** — include:
 
 - The full diff and commit list.
-- The complete contents of REVIEW-CRITERIA.md (smell baseline + project standards), and — if the target repo has one — the contents of its `.agent-docs/review.md` (repo-specific criteria accumulated from past Copilot reviews; treat its entries as documented standards, same status as REVIEW-CRITERIA.md).
+- The complete contents of REVIEW-CRITERIA.md (smell baseline + project standards), and — if the target repo has one — the contents of its `.agent-docs/review.md` (repo-specific criteria distilled from past Copilot findings that resulted in a code change, push-backs excluded; treat its entries as documented standards, same status as REVIEW-CRITERIA.md).
 - Brief: "Report per file/hunk: (a) every place the diff violates a documented standard — cite the rule; (b) every baseline smell — name and quote the hunk. Mark each finding as **blocking** or **advisory**. Documented-standard breaches may be blocking; baseline smells are always advisory. Skip anything tooling already enforces. Under 500 words."
 
 **Spec sub-agent prompt** — include:

--- a/code-review/SKILL.md
+++ b/code-review/SKILL.md
@@ -56,7 +56,7 @@ If the user supplied an explicit commit, branch, or tag, use that instead. A bad
 
 ## Step 4 — Spawn parallel review agents
 
-Read [REVIEW-CRITERIA.md](REVIEW-CRITERIA.md) in full. Capture the diff:
+Read [REVIEW-CRITERIA.md](REVIEW-CRITERIA.md) in full, and the target repo's `.agent-docs/review.md` if it exists (repo-specific criteria accumulated by `address-copilot-comments` from past Copilot reviews). Capture the diff:
 
 ```bash
 git diff origin/$BASE...HEAD
@@ -68,7 +68,7 @@ Send a **single message** with two `Agent` tool calls (type: `general-purpose`):
 **Standards sub-agent prompt** — include:
 
 - The full diff and commit list.
-- The complete contents of REVIEW-CRITERIA.md (smell baseline + project standards).
+- The complete contents of REVIEW-CRITERIA.md (smell baseline + project standards), and — if the target repo has one — the contents of its `.agent-docs/review.md` (repo-specific criteria accumulated from past Copilot reviews; treat its entries as documented standards, same status as REVIEW-CRITERIA.md).
 - Brief: "Report per file/hunk: (a) every place the diff violates a documented standard — cite the rule; (b) every baseline smell — name and quote the hunk. Mark each finding as **blocking** or **advisory**. Documented-standard breaches may be blocking; baseline smells are always advisory. Skip anything tooling already enforces. Under 500 words."
 
 **Spec sub-agent prompt** — include:

--- a/init-agent-docs/REFERENCE.md
+++ b/init-agent-docs/REFERENCE.md
@@ -136,15 +136,15 @@ Collect all matches found.
   > Please resolve manually by moving the correct file to `.agent-docs/context.md`, then
   > re-run this skill.
 
-- Skip to Step 7.
+- Skip to Step 6b.
 
 **If exactly one file is found**, move it to `.agent-docs/context.md`:
 
 1. Read the contents of the source file.
 2. Write those contents verbatim to `.agent-docs/context.md`.
-   - If the write fails, report the error clearly and skip to Step 7. Do **not** delete the source file.
+   - If the write fails, report the error clearly and skip to Step 6b. Do **not** delete the source file.
 3. Delete the source file only after the write succeeds.
-   - If the delete fails, report the error clearly and skip to Step 7. The destination file has already been written.
+   - If the delete fails, report the error clearly and skip to Step 6b. The destination file has already been written.
 
 If both steps succeed:
 
@@ -174,7 +174,7 @@ This step has two sub-paths depending on whether a `context.md` was found in Ste
      one- or two-sentence definition and an `_Avoid_` line listing synonyms to reject.
    - Subheadings grouping terms when natural clusters emerge.
 
-   If writing fails for any reason, report the error clearly and skip to Step 7.
+   If writing fails for any reason, report the error clearly and skip to Step 6b.
 
 4. Report: "Created `.agent-docs/context.md` from codebase analysis."
 
@@ -188,11 +188,40 @@ This step has two sub-paths depending on whether a `context.md` was found in Ste
    repos" section — this skill always bootstraps a single-context `context.md`.
 4. If shortcomings are found:
    - Write the improved file to `.agent-docs/context.md`.
-     If writing fails, report the error clearly and skip to Step 7.
+     If writing fails, report the error clearly and skip to Step 6b.
    - Report: "Improved `.agent-docs/context.md` — `<brief summary of changes>`."
 5. If no shortcomings are found:
    - Report: "`.agent-docs/context.md` reviewed — no improvements needed."
-   - Continue to Step 7 without writing.
+   - Continue to Step 6b without writing.
+
+## Step 6b — Bootstrap review.md
+
+`.agent-docs/review.md` holds review criteria this repository has accumulated from its own
+Copilot review rounds. It is written to by the `address-copilot-comments` skill (one
+generalised criterion per Copilot finding that resulted in a code change; push-backs are
+never recorded) and read by the `code-review` skill's Standards sub-agent as documented repo
+standards. This step only ensures the file exists — it never edits an existing one.
+
+Check whether `.agent-docs/review.md` already exists in the current repository.
+
+If it exists:
+
+- Report: "`.agent-docs/review.md` already exists — skipping."
+- Continue to Step 7.
+
+If it does not exist:
+
+1. Create the `.agent-docs/` directory if it does not already exist.
+2. Read the full contents of this skill's `REVIEW-TEMPLATE.md` file (located in the same
+   directory as this `REFERENCE.md`).
+3. Write those contents verbatim to `.agent-docs/review.md`.
+   - If the write fails, report the error clearly and continue to Step 7 — a missing
+     `review.md` does not block the rest of the bootstrap.
+4. Report: "Created `.agent-docs/review.md`."
+
+Unlike `context.md`, there is no search-for-a-file-to-move sub-path and no
+review-and-improve sub-path: the file is machine-maintained, so an existing one is left
+exactly as found.
 
 ## Step 7 — Migrate ADR files
 
@@ -284,6 +313,7 @@ init-agent-docs complete:
   - no agent-docs/ layout to migrate — skipped
   - Created `.agent-docs/agent.md`.
   - Created `.agent-docs/context.md` from codebase analysis.
+  - Created `.agent-docs/review.md`.
   - no ADRs found — skipped
   - Created `CLAUDE.md` with Agent Standards reference.
 ```
@@ -296,6 +326,7 @@ init-agent-docs complete:
   - `.agent-docs/agent.md` already exists — skipping.
   - `.agent-docs/context.md` found — proceeding to review.
   - Improved `.agent-docs/context.md` — tightened 2 definitions, added avoid-lists for 3 terms.
+  - Created `.agent-docs/review.md`.
   - no ADRs found — skipped
   - `CLAUDE.md` already references `.agent-docs/agent.md` — skipping.
 ```
@@ -307,6 +338,7 @@ init-agent-docs complete (nothing to do):
   - no agent-docs/ layout to migrate — skipped
   - `.agent-docs/agent.md` already exists — skipping.
   - `.agent-docs/context.md` reviewed — no improvements needed.
+  - `.agent-docs/review.md` already exists — skipping.
   - no ADRs found — skipped
   - `CLAUDE.md` already references `.agent-docs/agent.md` — skipping.
 ```

--- a/init-agent-docs/REVIEW-TEMPLATE.md
+++ b/init-agent-docs/REVIEW-TEMPLATE.md
@@ -1,0 +1,20 @@
+# Review Criteria (repo-specific)
+
+Review criteria this repository has accumulated from its own Copilot review rounds.
+
+- The `address-copilot-comments` skill appends a generalised, one-line criterion here for
+  every Copilot finding on a PR that resulted in a code change. Findings that were pushed
+  back on ("Ignored.") are never recorded — this file only holds criteria the team accepted
+  by changing code.
+- The `code-review` skill feeds this file to its Standards sub-agent alongside the skill's
+  own `REVIEW-CRITERIA.md`, and treats the entries here as documented repo standards (a
+  breach may be blocking).
+- Prune stale entries, and promote durable ones into a shared criteria file, by hand.
+
+Each entry is a bold label plus a one-line imperative rule, tagged with the PR it came
+from — for example:
+`- **Partial checks for compound state**: flag a readiness check that inspects one artefact when the state it gates has several parts. (PR #58)`
+
+## Criteria
+
+_None yet._

--- a/init-agent-docs/SKILL.md
+++ b/init-agent-docs/SKILL.md
@@ -1,13 +1,14 @@
 ---
 name: init-agent-docs
-description: Bootstraps AI agent documentation in the current repository — migrates any legacy agent-docs/ layout to .agent-docs/, creates .agent-docs/agent.md with default behavioural standards, bootstraps .agent-docs/context.md as a domain glossary, migrates existing ADR files from docs/ to .agent-docs/adr/, and ensures CLAUDE.md references .agent-docs/agent.md. Idempotent — reports what was created, migrated, or skipped on each run. Use at the start of any implementation workflow to ensure agent standards are in place before work begins.
+description: Bootstraps AI agent documentation in the current repository — migrates any legacy agent-docs/ layout to .agent-docs/, creates .agent-docs/agent.md with default behavioural standards, bootstraps .agent-docs/context.md as a domain glossary, creates .agent-docs/review.md from a template for accumulated review criteria, migrates existing ADR files from docs/ to .agent-docs/adr/, and ensures CLAUDE.md references .agent-docs/agent.md. Idempotent — reports what was created, migrated, or skipped on each run. Use at the start of any implementation workflow to ensure agent standards are in place before work begins.
 ---
 
 # init-agent-docs
 
-Bootstraps `.agent-docs/agent.md`, `.agent-docs/context.md`, and a `CLAUDE.md` reference in
-the current repository. When `.agent-docs/context.md` is present or moved into place, reviews
-it against the format rules and improves it only where needed.
+Bootstraps `.agent-docs/agent.md`, `.agent-docs/context.md`, `.agent-docs/review.md`, and a
+`CLAUDE.md` reference in the current repository. When `.agent-docs/context.md` is present or
+moved into place, reviews it against the format rules and improves it only where needed.
+`.agent-docs/review.md` is created from a template when missing and otherwise left untouched.
 
 > **Assumption**: this skill must be invoked from the repository root. It writes paths
 > relative to the current working directory.
@@ -20,8 +21,9 @@ See [REFERENCE.md](REFERENCE.md) for the full per-step detail.
 2. **Check for existing agent.md** — if `.agent-docs/agent.md` already exists, skip to Step 4.
 3. **Create agent.md** — write `AGENT-TEMPLATE.md` verbatim to `.agent-docs/agent.md`.
 4. **Check for existing context.md** — if `.agent-docs/context.md` already exists, go to Step 6.
-5. **Search for context.md to move** — look in the repo root and `docs/`; move if exactly one found, then go to Step 6; report ambiguity and skip to Step 7 if multiple found.
+5. **Search for context.md to move** — look in the repo root and `docs/`; move if exactly one found, then go to Step 6; report ambiguity and skip to Step 6b if multiple found.
 6. **Bootstrap or review context.md** — generate a full domain glossary from the codebase if no file exists; otherwise review and improve the existing file against `CONTEXT-FORMAT.md`, or report "no improvements needed" if already compliant.
+6b. **Bootstrap review.md** — if `.agent-docs/review.md` is missing, write `REVIEW-TEMPLATE.md` verbatim; if it already exists, leave it untouched. It is machine-maintained by `address-copilot-comments`, so there is no move-from-elsewhere or review-and-improve sub-path.
 7. **Migrate ADR files** — search `docs/`, `docs/adr/`, `agent-docs/docs/adr/`, and `.agent-docs/docs/adr/` for ADR files matching `[0-9]*-*.md`; move them to `.agent-docs/adr/`, resolving conflicts by git date.
 8. **Check CLAUDE.md** — if `CLAUDE.md` already references `.agent-docs/agent.md`, skip to Step 10; if it references the old path, update it.
 9. **Create or append CLAUDE.md** — append the Agent Standards reference block to `CLAUDE.md` (create if missing).


### PR DESCRIPTION
Closes #61, closes #62, closes #63.

## What

A per-repo `.agent-docs/review.md` that accumulates review criteria from that repository's own Copilot reviews, wired across three skills:

- **`init-agent-docs`** — new `REVIEW-TEMPLATE.md` and **Step 6b** (after context.md, before ADR migration): write the template verbatim when `.agent-docs/review.md` is missing; leave an existing one untouched. Steps 7–10 keep their numbers; context.md failure hand-offs now flow to Step 6b. Frontmatter, intro, and all three Step 10 summary examples updated.
- **`address-copilot-comments`** — new **Step 7b** after the Copilot loop: for every finding this invocation that got a **Fix** (threads + suppressed, all rounds), generalise it into a one-line criterion in `REVIEW-CRITERIA.md`'s voice tagged `(PR #N)`, dedupe against the target repo's `.agent-docs/review.md`, append, and commit that file on its own to the PR branch. Push-backs record nothing. Exempt PRs and zero-fix loops skip the step. Loop-termination routing now passes through 7b instead of jumping to Step 8.
- **`code-review`** — Step 4 also reads the target repo's `.agent-docs/review.md` when present and passes it to the Standards sub-agent as documented standards, same status as `REVIEW-CRITERIA.md`. Absent file → prompt unchanged.

Also: this repo dogfoods it (`.agent-docs/review.md` at `_None yet._`, `review.md` term in `context.md`). No change to `agent.md`.

Spec: `.agent-docs/specs/feature/review-md-feedback-loop.md`.

## Cross-skill consistency (AC)

`.agent-docs/review.md` path, the "fixes-only, push-backs never recorded" rule, and "treat as documented standards" are stated consistently across `REVIEW-TEMPLATE.md`, `init-agent-docs` REFERENCE Step 6b, `address-copilot-comments` SKILL Step 7b + REFERENCE, `code-review` SKILL Step 4, and this repo's `context.md`. The template header has a single source: `address-copilot-comments` REFERENCE points at `REVIEW-TEMPLATE.md` rather than copying it.

## Test plan

Docs-only (three skills defined in markdown + one template + repo docs); no code seam, consistent with prior skill changes. `pre-commit` clean on changed-files and full-repo passes. Traced on paper:

1. `init-agent-docs` with no `.agent-docs/review.md` → created from template; re-run → "already exists — skipping".
2. `address-copilot-comments` where round 1 fixes two findings and round 2 pushes back one → the two fixed findings generalised, deduped, committed; the push-back leaves nothing; an exempt PR writes nothing.
3. `code-review` Step 4 with a populated `.agent-docs/review.md` → its criteria in the Standards prompt as documented standards; absent → prompt byte-identical to today.

## Note

This diff contains step-logic edits to `SKILL.md`/`REFERENCE.md` for three skills, so it is **review-required** under `address-copilot-comments`'s own classification rule.
