### PR TITLE
Run BDD implementation loop in a clean-context subagent

### DIFF
--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -123,7 +123,7 @@ The red-green-refactor cycle used in the `behaviour-driven-development` skill: w
 _Avoid_: TDD cycle, test loop, test-first loop
 
 **Implementation subagent** (BDD sense):
-The fresh-context `general-purpose` agent the `behaviour-driven-development` skill spawns to run the red-green-refactor loop, after the test-authoring context has agreed the scenarios and written the failing tracer bullet test. Receives the agreed scenario list and interface changes inline in its prompt, then grinds the vertical loop — one scenario → test → minimal implementation → repeat — then refactors. Production code is never written in the design-polluted test-authoring context.
+The fresh-context `general-purpose` agent the `behaviour-driven-development` skill spawns to run the red-green-refactor loop, after the test-authoring context has agreed the scenarios and written the failing tracer bullet test. Receives the agreed scenario list and interface changes inline in its prompt, then grinds the vertical loop — one scenario → test → minimal implementation → repeat — then refactors. Told not to re-invoke the `bdd` skill, so the loop cannot recurse. Production code is never written in the design-polluted test-authoring context.
 _Avoid_: impl agent, worker agent, coding subagent
 
 **Pre-commit check**:

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -123,7 +123,7 @@ The red-green-refactor cycle used in the `behaviour-driven-development` skill: w
 _Avoid_: TDD cycle, test loop, test-first loop
 
 **Implementation subagent** (BDD sense):
-The fresh-context `general-purpose` agent the `behaviour-driven-development` skill spawns to run the red-green-refactor loop, after the test-authoring context has agreed the scenarios and written the failing tracer bullet test. Receives the agreed scenario list and interface changes inline in its prompt, then grinds the vertical loop — one scenario → test → minimal implementation → repeat — then refactors. Told not to re-invoke the `bdd` skill, so the loop cannot recurse. On the normal path it writes every line of production code, keeping it out of the design-polluted test-authoring context.
+The fresh-context `general-purpose` agent the `behaviour-driven-development` skill spawns to run the red-green-refactor loop, after the test-authoring context has agreed the scenarios and written the failing tracer bullet test. Receives the agreed scenario list and interface changes inline in its prompt, then grinds the vertical loop — one scenario → test → minimal implementation → repeat — then refactors. Told not to re-invoke the `bdd` skill, so the loop does not recurse. On the normal path it writes every line of production code.
 _Avoid_: impl agent, worker agent, coding subagent
 
 **Pre-commit check**:

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -119,8 +119,12 @@ A unit of work that delivers end-to-end value, used by `create-issues` to break 
 _Avoid_: story, task, feature slice
 
 **BDD loop**:
-The red-green-refactor cycle used in the `behaviour-driven-development` skill: write a failing Given-When-Then scenario, implement to pass it, then refactor.
+The red-green-refactor cycle used in the `behaviour-driven-development` skill: write a failing Given-When-Then scenario, implement to pass it, then refactor. Split across a context boundary — the test-authoring context agrees the scenario list and writes the tracer bullet test (RED), then hands off to a clean **implementation subagent** that runs the vertical loop and refactor.
 _Avoid_: TDD cycle, test loop, test-first loop
+
+**Implementation subagent** (BDD sense):
+The fresh-context `general-purpose` agent the `behaviour-driven-development` skill spawns to run the red-green-refactor loop, after the test-authoring context has agreed the scenarios and written the failing tracer bullet test. Receives the agreed scenario list and interface changes inline in its prompt, then grinds the vertical loop — one scenario → test → minimal implementation → repeat — then refactors. Production code is never written in the design-polluted test-authoring context.
+_Avoid_: impl agent, worker agent, coding subagent
 
 **Pre-commit check**:
 Validation driven by `.pre-commit-config.yaml` or `.githooks/pre-commit`, run by the `pre-commit-check` skill after every code change. Runs in two sequential passes: changed files first, then a full-repo pass (`--all-files`) that fixes any drift found repo-wide, even in untouched files.

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -123,7 +123,7 @@ The red-green-refactor cycle used in the `behaviour-driven-development` skill: w
 _Avoid_: TDD cycle, test loop, test-first loop
 
 **Implementation subagent** (BDD sense):
-The fresh-context `general-purpose` agent the `behaviour-driven-development` skill spawns to run the red-green-refactor loop, after the test-authoring context has agreed the scenarios and written the failing tracer bullet test. Receives the agreed scenario list and interface changes inline in its prompt, then grinds the vertical loop — one scenario → test → minimal implementation → repeat — then refactors. Told not to re-invoke the `bdd` skill, so the loop cannot recurse. Production code is never written in the design-polluted test-authoring context.
+The fresh-context `general-purpose` agent the `behaviour-driven-development` skill spawns to run the red-green-refactor loop, after the test-authoring context has agreed the scenarios and written the failing tracer bullet test. Receives the agreed scenario list and interface changes inline in its prompt, then grinds the vertical loop — one scenario → test → minimal implementation → repeat — then refactors. Told not to re-invoke the `bdd` skill, so the loop cannot recurse. On the normal path it writes every line of production code, keeping it out of the design-polluted test-authoring context.
 _Avoid_: impl agent, worker agent, coding subagent
 
 **Pre-commit check**:

--- a/.agent-docs/issues/chore/bdd-clean-context-impl.md
+++ b/.agent-docs/issues/chore/bdd-clean-context-impl.md
@@ -1,0 +1,53 @@
+# Issues: chore/bdd-clean-context-impl
+
+## Split BDD workflow into test-authoring phase + clean-context implementation subagent
+
+**GitHub**: #71
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3, 4, 5, 6, 7
+
+### What to build
+
+Restructure the `behaviour-driven-development` skill so its implementation loop runs in a
+fresh `general-purpose` subagent, started after the test-authoring phase has agreed the
+scenario list and written a single failing tracer bullet test. The agreed scenarios and
+interface changes are passed inline in the subagent prompt (no new on-disk artifact). The
+subagent runs the red-green-refactor loop vertically and reports back; the main context
+verifies against the per-cycle checklist. The "Anti-Pattern: Horizontal Slices" section is
+kept intact with only an additive clarification and a diagram tweak. Only `SKILL.md` and
+`WORKFLOW.md` in the skill change.
+
+### Acceptance criteria
+
+- [ ] `SKILL.md` "Anti-Pattern: Horizontal Slices" prohibition text is unchanged; one added
+      paragraph states the handoff crosses the boundary with exactly one failing test (the
+      tracer bullet), the subagent writes every remaining test one at a time, and batching
+      all tests upfront stays forbidden in both contexts.
+- [ ] `SKILL.md` `WRONG`/`RIGHT` diagram gains a context-boundary line: the boundary sits
+      between the tracer test and the loop; the loop stays `test1→impl1, test2→impl2, …`
+      inside the subagent.
+- [ ] `SKILL.md` closing "See WORKFLOW.md" pointer line names the phase split.
+- [ ] `WORKFLOW.md` Step 3 is the tracer bullet test only (RED): confirm it fails for the
+      right reason (not an import/collection error); no production code written.
+- [ ] `WORKFLOW.md` Step 4 dispatches one `Agent` call (`type: general-purpose`) whose
+      prompt carries inline: the user stories, the full Given-When-Then scenario list, the
+      confirmed interface changes, path(s) to the failing tracer test file(s), the core
+      loop rules (red-green vertical, one scenario at a time, minimal code to pass, never
+      refactor while red, test observable behaviour only, refactor once green), pointers to
+      `tests.md` / `mocking.md` / `refactoring.md`, and an explicit "do not re-invoke the
+      `bdd` skill" instruction. The subagent returns per-scenario status (green / not
+      satisfied + why), refactors applied, and the final test-run output.
+- [ ] `WORKFLOW.md` Step 5 has the main context verify the returned result against the
+      per-cycle checklist, confirm every scenario is covered and green, and review the
+      subagent's refactors. `pre-commit-check` and commit remain the caller's
+      responsibility. A scenario the subagent cannot satisfy: it stops and reports; the
+      main context decides (fix inline or re-dispatch a narrower subagent); no automatic
+      retry loop in the skill.
+- [ ] Behaviour is identical whether `bdd` is invoked standalone or as `/implement` Step 6.
+- [ ] Only `behaviour-driven-development/SKILL.md` and
+      `behaviour-driven-development/WORKFLOW.md` are modified in the skill.
+- [ ] `pre-commit-check` passes on all changed files.
+
+---

--- a/.agent-docs/issues/chore/bdd-clean-context-impl.md
+++ b/.agent-docs/issues/chore/bdd-clean-context-impl.md
@@ -1,5 +1,7 @@
 # Issues: chore/bdd-clean-context-impl
 
+> Work complete — PR ready to merge.
+
 ## Split BDD workflow into test-authoring phase + clean-context implementation subagent
 
 **GitHub**: #71
@@ -21,17 +23,17 @@ kept intact with only an additive clarification and a diagram tweak. Only `SKILL
 
 ### Acceptance criteria
 
-- [ ] `SKILL.md` "Anti-Pattern: Horizontal Slices" prohibition text is unchanged; one added
+- [x] `SKILL.md` "Anti-Pattern: Horizontal Slices" prohibition text is unchanged; one added
       paragraph states the handoff crosses the boundary with exactly one failing test (the
       tracer bullet), the subagent writes every remaining test one at a time, and batching
       all tests upfront stays forbidden in both contexts.
-- [ ] `SKILL.md` `WRONG`/`RIGHT` diagram gains a context-boundary line: the boundary sits
+- [x] `SKILL.md` `WRONG`/`RIGHT` diagram gains a context-boundary line: the boundary sits
       between the tracer test and the loop; the loop stays `test1→impl1, test2→impl2, …`
       inside the subagent.
-- [ ] `SKILL.md` closing "See WORKFLOW.md" pointer line names the phase split.
-- [ ] `WORKFLOW.md` Step 3 is the tracer bullet test only (RED): confirm it fails for the
+- [x] `SKILL.md` closing "See WORKFLOW.md" pointer line names the phase split.
+- [x] `WORKFLOW.md` Step 3 is the tracer bullet test only (RED): confirm it fails for the
       right reason (not an import/collection error); no production code written.
-- [ ] `WORKFLOW.md` Step 4 dispatches one `Agent` call (`type: general-purpose`) whose
+- [x] `WORKFLOW.md` Step 4 dispatches one `Agent` call (`type: general-purpose`) whose
       prompt carries inline: the user stories, the full Given-When-Then scenario list, the
       confirmed interface changes, path(s) to the failing tracer test file(s), the core
       loop rules (red-green vertical, one scenario at a time, minimal code to pass, never
@@ -39,15 +41,15 @@ kept intact with only an additive clarification and a diagram tweak. Only `SKILL
       `tests.md` / `mocking.md` / `refactoring.md`, and an explicit "do not re-invoke the
       `bdd` skill" instruction. The subagent returns per-scenario status (green / not
       satisfied + why), refactors applied, and the final test-run output.
-- [ ] `WORKFLOW.md` Step 5 has the main context verify the returned result against the
+- [x] `WORKFLOW.md` Step 5 has the main context verify the returned result against the
       per-cycle checklist, confirm every scenario is covered and green, and review the
       subagent's refactors. `pre-commit-check` and commit remain the caller's
       responsibility. A scenario the subagent cannot satisfy: it stops and reports; the
       main context decides (fix inline or re-dispatch a narrower subagent); no automatic
       retry loop in the skill.
-- [ ] Behaviour is identical whether `bdd` is invoked standalone or as `/implement` Step 6.
-- [ ] Only `behaviour-driven-development/SKILL.md` and
+- [x] Behaviour is identical whether `bdd` is invoked standalone or as `/implement` Step 6.
+- [x] Only `behaviour-driven-development/SKILL.md` and
       `behaviour-driven-development/WORKFLOW.md` are modified in the skill.
-- [ ] `pre-commit-check` passes on all changed files.
+- [x] `pre-commit-check` passes on all changed files.
 
 ---

--- a/.agent-docs/review.md
+++ b/.agent-docs/review.md
@@ -25,3 +25,10 @@ from — for example:
   (`SKILL.md`/`REFERENCE.md`/`WORKFLOW.md`) that carries a literal example value or a
   placeholder token the step never derives — an agent runs these verbatim. Prefer a command
   form that needs no substitution. (PR #70)
+- **Edit outside a declared no-change boundary**: when the issue or spec fences an existing
+  section as "kept verbatim / additive clarification only", flag any reword of that
+  section's existing sentences — even an accuracy fix belongs in the added material, not the
+  frozen text. (PR #72)
+- **Ambiguous cadence in an instruction step**: flag a directive to act "after every X" or
+  "once Y" that does not say whether it runs each iteration or a single time at the end — an
+  agent following it can pick the wrong cadence. (PR #72)

--- a/.agent-docs/specs/chore/bdd-clean-context-impl.md
+++ b/.agent-docs/specs/chore/bdd-clean-context-impl.md
@@ -73,11 +73,12 @@ kept verbatim and clarified with an additive paragraph and a diagram tweak.
     not write production code.
   - **Step 4 — Dispatch the implementation subagent**: one `Agent` call, `type:
     general-purpose`. Prompt contains, inline: the agreed user stories, the full
-    Given-When-Then scenario list, the confirmed interface changes, the path(s) to the
-    failing tracer test file(s), the core loop rules (red-green vertical, one scenario at a
-    time, minimal code to pass, never refactor while red, test observable behaviour only,
-    refactor once green), and pointers to `tests.md` / `mocking.md` / `refactoring.md` for
-    depth. Explicit instruction: do not re-invoke the `bdd` skill. The subagent returns a
+    Given-When-Then scenario list, the confirmed interface changes, the path to the
+    failing tracer test file and the command that runs it (captured in Step 3), the core
+    loop rules (red-green vertical, one scenario at a time, minimal code to pass, never
+    refactor while red, test observable behaviour only, refactor once green), the per-cycle
+    and refactor checklists, and pointers to `tests.md` / `mocking.md` / `refactoring.md`
+    for depth. Explicit instruction: do not re-invoke the `bdd` skill. The subagent returns a
     per-scenario status (green / not satisfied + why), the refactors applied, and the final
     test-run output.
   - **Step 5 — Verify and refactor review**: main context runs the per-cycle checklist

--- a/.agent-docs/specs/chore/bdd-clean-context-impl.md
+++ b/.agent-docs/specs/chore/bdd-clean-context-impl.md
@@ -1,0 +1,126 @@
+# BDD Skill — Clean-Context Implementation Handoff
+
+## Problem Statement
+
+By the time the `behaviour-driven-development` skill reaches its implementation loop, the
+context window is saturated with test-authoring noise: the Three Amigos conversation, design
+exploration, interface debate, and false starts. Production code written in that polluted
+context tends to be biased toward the shape the discussion imagined rather than what the
+tests actually specify. The maintainer wants the implementation to begin from a clean
+context that treats the agreed tests as the specification.
+
+## Solution
+
+Split the BDD workflow at a context boundary:
+
+- **Test-authoring phase** stays in the main context: run the Three Amigos, agree the
+  Given-When-Then scenario list, confirm interface changes, and write the single tracer
+  bullet test (RED) — confirming it fails for the right reason. No production code is
+  written here.
+- **Implementation phase** runs in a fresh `general-purpose` subagent the skill spawns. It
+  receives the agreed scenario list and interface changes inline in its prompt, plus the
+  path to the failing tracer test. It runs the red-green-refactor loop vertically — one
+  scenario at a time, test → minimal implementation → repeat — then refactors, then reports
+  back per scenario with the final test output.
+- The main context then verifies the result against the per-cycle checklist, runs
+  `pre-commit-check`, and (under `/implement`) commits.
+
+Vertical slicing is preserved: exactly one failing test crosses the boundary, and the
+subagent writes every remaining test one at a time. What moves across the boundary is the
+design noise, not a batch of tests. The "Anti-Pattern: Horizontal Slices" prohibition is
+kept verbatim and clarified with an additive paragraph and a diagram tweak.
+
+## User Stories
+
+1. As an agent running the `bdd` skill, I want the implementation loop to run in a fresh
+   subagent, so that production code is written against the agreed tests without the
+   design conversation biasing it.
+2. As an agent running the `bdd` skill, I want the test-authoring phase to stop after the
+   tracer bullet test (RED), so that no production code is written in the polluted context.
+3. As an agent spawning the implementation subagent, I want the agreed scenario list and
+   interface changes passed inline in the prompt, so that the handoff survives the context
+   boundary without a new on-disk artifact.
+4. As an agent running the implementation subagent, I want the red-green-refactor loop
+   rules and pointers to `tests.md` / `mocking.md` / `refactoring.md` in my prompt, so that
+   I run the vertical loop correctly without re-invoking the `bdd` skill.
+5. As an agent that has received the subagent's report, I want to verify it against the
+   per-cycle checklist and run `pre-commit-check` in the main context, so that the skill's
+   existing quality gates still apply.
+6. As a maintainer, I want the "Anti-Pattern: Horizontal Slices" section kept intact with
+   only an additive clarification, so that the prohibition on batching all tests upfront is
+   not weakened by the phase split.
+7. As an agent, I want the behaviour to be identical whether `bdd` is invoked standalone or
+   as `/implement` Step 6, so that there is one code path to reason about.
+
+## Implementation Decisions
+
+- **Files changed**: `behaviour-driven-development/SKILL.md` and
+  `behaviour-driven-development/WORKFLOW.md` only. Supporting `.md` files
+  (`tests.md`, `mocking.md`, `refactoring.md`, `deep-modules.md`, `interface-design.md`)
+  are unchanged — they are referenced by path from the subagent prompt.
+- **`SKILL.md`**:
+  - "Anti-Pattern: Horizontal Slices" — prohibition text unchanged. Add one paragraph:
+    the clean-context handoff happens with exactly one failing test (the tracer bullet);
+    the subagent writes every remaining test one at a time; batching all tests upfront
+    stays forbidden in both contexts; what crosses the boundary is design noise, not tests.
+  - The `WRONG`/`RIGHT` diagram gains a line showing the context boundary sitting between
+    the tracer test and the loop, with the loop still `test1→impl1, test2→impl2, …` inside
+    the subagent.
+  - The closing "See WORKFLOW.md …" pointer line updated to name the phase split.
+- **`WORKFLOW.md`**: restructure Steps 3–5.
+  - **Step 3 — Tracer bullet test (authoring phase)**: write only the first scenario's
+    test (RED); confirm it fails for the right reason (not a collection/import error). Do
+    not write production code.
+  - **Step 4 — Dispatch the implementation subagent**: one `Agent` call, `type:
+    general-purpose`. Prompt contains, inline: the agreed user stories, the full
+    Given-When-Then scenario list, the confirmed interface changes, the path(s) to the
+    failing tracer test file(s), the core loop rules (red-green vertical, one scenario at a
+    time, minimal code to pass, never refactor while red, test observable behaviour only,
+    refactor once green), and pointers to `tests.md` / `mocking.md` / `refactoring.md` for
+    depth. Explicit instruction: do not re-invoke the `bdd` skill. The subagent returns a
+    per-scenario status (green / not satisfied + why), the refactors applied, and the final
+    test-run output.
+  - **Step 5 — Verify and refactor review**: main context runs the per-cycle checklist
+    against the returned result, confirms every scenario is covered and green, and folds
+    the former "Refactor" checklist in as a review of what the subagent did. `pre-commit-check`
+    and commit remain the caller's responsibility (unchanged under `/implement` Step 6).
+  - A scenario the subagent cannot satisfy: it stops and reports; the main context decides
+    (fix inline, or re-dispatch a fresh subagent with a narrower brief). No automatic retry
+    loop in the skill.
+- **Standalone vs `/implement`**: the skill dispatches the subagent itself, so both entry
+  paths behave identically. `/implement` Step 6's "run the `bdd` skill … then
+  `pre-commit-check` … then commit" ordering is unaffected.
+- **CONTEXT.md** (already updated in this session): `BDD loop` entry sharpened to name the
+  context boundary; new `Implementation subagent` (BDD sense) term added.
+- **No ADR**: fails the "hard to reverse" test — this is prose in a skill definition,
+  trivially revertible. The rationale lives in the reconciliation paragraph in `SKILL.md`.
+
+## Testing Decisions
+
+- This repo has no automated test infrastructure; skills are prose markdown. Verification
+  is a read-through against the acceptance criteria plus the `pre-commit-check` pass
+  (markdownlint and the configured hooks). This matches prior doc-only chore specs in
+  `.agent-docs/specs/chore/`.
+- Prior art: `.agent-docs/specs/chore/step4b-explicit-skip-guard.md` and
+  `.agent-docs/specs/chore/step4b-foreground-requirement.md` — same shape of change
+  (restructuring workflow-step prose in a skill).
+- Because the deliverable is prose, no implementation subagent is spawned for *this* issue;
+  the change is made directly and verified by read-through.
+
+## Out of Scope
+
+- The Three Amigos / planning process itself (Step 1) — unchanged.
+- `/implement`'s other steps — unchanged.
+- Supporting `.md` files in the BDD skill except where they are referenced by the new
+  Step 4 prompt.
+- Any executable test harness for skills — none exists and none is added here.
+- Retry/backoff logic for a stuck subagent beyond "stop and report".
+
+## Further Notes
+
+- The subagent prompt pattern mirrors `code-review/SKILL.md` Step 4, which also passes
+  everything (diff, criteria) inline to `type: general-purpose` agents rather than via a
+  file.
+- The tracer bullet test is written in the main context (not the subagent) deliberately:
+  it de-risks the handoff by proving the outside-in path is expressible as a failing test
+  in this codebase's test setup before a subagent is spent on it.

--- a/behaviour-driven-development/SKILL.md
+++ b/behaviour-driven-development/SKILL.md
@@ -72,7 +72,7 @@ RIGHT (vertical):
 
 ### The clean-context handoff is not horizontal slicing
 
-The implementation phase runs in a fresh subagent (see [WORKFLOW.md](WORKFLOW.md) Steps 3–5). Exactly **one** failing test crosses that boundary — the tracer bullet. The subagent then writes every remaining test one at a time, each responding to what the previous cycle taught, exactly as in the vertical model above. Batching all tests upfront stays forbidden — in the test-authoring context and inside the subagent alike. What moves across the boundary is the design noise — the Three Amigos discussion, interface debate, false starts — not a pile of tests.
+The implementation phase runs in a fresh subagent (see [WORKFLOW.md](WORKFLOW.md) Step 4). The first handoff carries exactly **one** failing test — the tracer bullet. The subagent then writes every remaining test one at a time, each responding to what the previous cycle taught, exactly as in the vertical model above. Batching all tests upfront stays forbidden — in the test-authoring context and inside the subagent alike. What moves across the boundary is the design noise — the Three Amigos discussion, interface debate, false starts — not a pile of tests.
 
 ## Workflow
 

--- a/behaviour-driven-development/SKILL.md
+++ b/behaviour-driven-development/SKILL.md
@@ -53,7 +53,7 @@ This produces **crap tests**:
 - Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
 - You outrun your headlights, committing to test structure before understanding the implementation
 
-**Correct approach**: Vertical slices via a tracer bullet, then one test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because each test and the code that passes it are written in the same pass, you know exactly what behavior matters and how to verify it.
+**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
 
 ```text
 WRONG (horizontal):

--- a/behaviour-driven-development/SKILL.md
+++ b/behaviour-driven-development/SKILL.md
@@ -61,12 +61,19 @@ WRONG (horizontal):
   GREEN: impl1, impl2, impl3, impl4, impl5
 
 RIGHT (vertical):
-  RED→GREEN: test1→impl1
-  RED→GREEN: test2→impl2
-  RED→GREEN: test3→impl3
-  ...
+  authoring context ──▸ write test1 (RED)
+  ─────────────── clean-context handoff ───────────────
+  implementation subagent:
+    RED→GREEN: test1→impl1
+    RED→GREEN: test2→impl2
+    RED→GREEN: test3→impl3
+    ...
 ```
+
+### The clean-context handoff is not horizontal slicing
+
+The implementation phase runs in a fresh subagent (see [WORKFLOW.md](WORKFLOW.md) Steps 3–5). Exactly **one** failing test crosses that boundary — the tracer bullet. The subagent then writes every remaining test one at a time, each responding to what the previous cycle taught, exactly as in the vertical model above. Batching all tests upfront stays forbidden — in the test-authoring context and inside the subagent alike. What moves across the boundary is the design noise — the Three Amigos discussion, interface debate, false starts — not a pile of tests.
 
 ## Workflow
 
-See [WORKFLOW.md](WORKFLOW.md) for the full step-by-step cycle: branch check → planning → tracer bullet → incremental loop → refactor → checklist.
+See [WORKFLOW.md](WORKFLOW.md) for the full step-by-step cycle: branch check → planning → tracer bullet test → clean-context handoff → implementation subagent (incremental loop + refactor) → verification.

--- a/behaviour-driven-development/SKILL.md
+++ b/behaviour-driven-development/SKILL.md
@@ -53,7 +53,7 @@ This produces **crap tests**:
 - Tests become insensitive to real changes - they pass when behavior breaks, fail when behavior is fine
 - You outrun your headlights, committing to test structure before understanding the implementation
 
-**Correct approach**: Vertical slices via tracer bullets. One test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because you just wrote the code, you know exactly what behavior matters and how to verify it.
+**Correct approach**: Vertical slices via a tracer bullet, then one test → one implementation → repeat. Each test responds to what you learned from the previous cycle. Because each test and the code that passes it are written in the same pass, you know exactly what behavior matters and how to verify it.
 
 ```text
 WRONG (horizontal):
@@ -61,12 +61,12 @@ WRONG (horizontal):
   GREEN: impl1, impl2, impl3, impl4, impl5
 
 RIGHT (vertical):
-  authoring context ──▸ write test1 (RED)
+  authoring context ──▸ write test1 (RED), then stop
   ─────────────── clean-context handoff ───────────────
   implementation subagent:
-    RED→GREEN: test1→impl1
-    RED→GREEN: test2→impl2
-    RED→GREEN: test3→impl3
+    GREEN:     test1 → impl1     (make the tracer bullet pass)
+    RED→GREEN: test2 → impl2
+    RED→GREEN: test3 → impl3
     ...
 ```
 

--- a/behaviour-driven-development/WORKFLOW.md
+++ b/behaviour-driven-development/WORKFLOW.md
@@ -63,7 +63,7 @@ This is your tracer bullet: it proves the first scenario is expressible as a fai
 
 The main context is now saturated with planning, the Three Amigos discussion, interface debate, and false starts. Production code written here would be biased toward the shape that discussion imagined rather than what the tests specify. So the implementation loop runs in a **fresh subagent** that treats the agreed scenarios as its specification.
 
-Dispatch **one** `Agent` call, `type: general-purpose`. Everything the subagent needs goes **inline in the prompt** — nothing new is written to disk:
+Dispatch **one** `Agent` call, `type: general-purpose`. Everything the subagent needs goes **inline in the prompt** — no handoff file is written to disk:
 
 - The agreed user stories.
 - The full Given-When-Then scenario list from Step 1, in order.

--- a/behaviour-driven-development/WORKFLOW.md
+++ b/behaviour-driven-development/WORKFLOW.md
@@ -55,6 +55,8 @@ RED: Write the test for the first behaviour → run it → it fails
 
 Confirm it fails *for the right reason* — an assertion failure, or a missing function / endpoint / module — not an import error, a syntax error, or a test-collection failure. A test that errors before it runs has proven nothing about the path.
 
+Note the exact command that runs the suite (or this test alone); Step 4 passes it to the subagent verbatim.
+
 This is your tracer bullet: it proves the first scenario is expressible as a failing test in this codebase's test setup, which de-risks the handoff that follows.
 
 ## Step 4 — Hand off to the implementation subagent (clean context)
@@ -66,7 +68,7 @@ Dispatch **one** `Agent` call, `type: general-purpose`. Everything the subagent 
 - The agreed user stories.
 - The full Given-When-Then scenario list from Step 1, in order.
 - The confirmed interface changes.
-- The path(s) to the failing tracer bullet test file(s) from Step 3, and the command that runs the test suite.
+- The path to the failing tracer bullet test file from Step 3, and the test command noted there.
 - The loop rules, verbatim:
   - Work one scenario at a time, in order. RED: write the next test → it fails. GREEN: write the minimal code to pass it → it passes.
   - Only enough code to pass the current test. Don't anticipate later scenarios.
@@ -97,10 +99,9 @@ If the subagent reports a scenario it could not satisfy, it stops there. The mai
 Back in the main context, check the subagent's report:
 
 - [ ] Every scenario from Step 1 has a corresponding test, and the full suite is green
-- [ ] Each test uses domain vocabulary and maps to a Given-When-Then scenario
-- [ ] Tests exercise observable behaviour through the public interface — they would survive an internal refactor
-- [ ] No speculative features beyond the agreed scenarios
+- [ ] Every item of the Step 4 per-cycle checklist holds for the tests the subagent wrote
 - [ ] The refactors applied are sound and the suite is still green after them
+- [ ] No speculative features beyond the agreed scenarios
 
 If anything fails the check, address it in the main context or re-dispatch a subagent.
 

--- a/behaviour-driven-development/WORKFLOW.md
+++ b/behaviour-driven-development/WORKFLOW.md
@@ -74,7 +74,7 @@ Dispatch **one** `Agent` call, `type: general-purpose`. Everything the subagent 
   - Only enough code to pass the current test. Don't anticipate later scenarios.
   - Test observable behaviour through the public interface, not internals.
   - Never refactor while RED — get to GREEN first.
-  - After every scenario is green, refactor (checklist below), running the full suite after each step.
+  - Refactor only after the whole scenario list is green — one refactor pass at the end, not after each scenario — running the full suite after each refactor step.
 - The per-cycle checklist, for the subagent to apply to every scenario:
   - Test name uses domain vocabulary, not implementation terms
   - Test maps to a Given-When-Then scenario or acceptance criterion
@@ -83,7 +83,7 @@ Dispatch **one** `Agent` call, `type: general-purpose`. Everything the subagent 
   - Test would survive an internal refactor
   - Code is minimal for this test
   - No speculative features added
-- The refactor checklist, to apply once green (see `refactoring.md`):
+- The refactor checklist, for that final pass once the whole list is green (see `refactoring.md`):
   - Extract duplication
   - Deepen modules (move complexity behind simple interfaces)
   - Apply SOLID principles where natural

--- a/behaviour-driven-development/WORKFLOW.md
+++ b/behaviour-driven-development/WORKFLOW.md
@@ -70,7 +70,7 @@ Dispatch **one** `Agent` call, `type: general-purpose`. Everything the subagent 
 - The confirmed interface changes.
 - The path to the failing tracer bullet test file from Step 3, and the test command noted there.
 - The loop rules, verbatim:
-  - Work one scenario at a time, in order. RED: write the next test → it fails. GREEN: write the minimal code to pass it → it passes.
+  - Work one scenario at a time, in order. RED: write the next test → it fails. GREEN: write the minimal code to pass it → it passes. Scenario 1's test already exists from Step 3 — start at GREEN for it.
   - Only enough code to pass the current test. Don't anticipate later scenarios.
   - Test observable behaviour through the public interface, not internals.
   - Never refactor while RED — get to GREEN first.

--- a/behaviour-driven-development/WORKFLOW.md
+++ b/behaviour-driven-development/WORKFLOW.md
@@ -45,53 +45,63 @@ Determine `change_type` from the Three Amigos output:
 
 Pass this to branch-hygiene so it can accurately validate the branch prefix and suggest a correctly-named branch if needed. If Step 0 already moved the user to a `wip/` placeholder, branch-hygiene will detect this as a mismatch and prompt for a proper name. **Do not push or commit to any new branch.**
 
-## Step 3 — Tracer Bullet
+## Step 3 — Tracer Bullet Test (authoring phase)
 
-Write ONE test that confirms ONE thing about the system:
-
-```text
-RED:   Write test for first behavior → test fails
-GREEN: Write minimal code to pass → test passes
-```
-
-This is your tracer bullet - proves the path works end-to-end.
-
-## Step 4 — Incremental Loop
-
-For each remaining behavior:
+Still in the main context, write ONE test for the **first scenario** — and stop there. **Do not write any production code in this phase.**
 
 ```text
-RED:   Write next test → fails
-GREEN: Minimal code to pass → passes
+RED: Write the test for the first behaviour → run it → it fails
 ```
 
-Rules:
+Confirm it fails *for the right reason* — an assertion failure, or a missing function / endpoint / module — not an import error, a syntax error, or a test-collection failure. A test that errors before it runs has proven nothing about the path.
 
-- One test at a time
-- Only enough code to pass current test
-- Don't anticipate future tests
-- Keep tests focused on observable behavior
+This is your tracer bullet: it proves the first scenario is expressible as a failing test in this codebase's test setup, which de-risks the handoff that follows.
 
-## Step 5 — Refactor
+## Step 4 — Hand off to the implementation subagent (clean context)
 
-After all tests pass, look for refactor candidates (see `refactoring.md`):
+The main context is now saturated with planning, the Three Amigos discussion, interface debate, and false starts. Production code written here would be biased toward the shape that discussion imagined rather than what the tests specify. So the implementation loop runs in a **fresh subagent** that treats the agreed scenarios as its specification.
 
-- [ ] Extract duplication
-- [ ] Deepen modules (move complexity behind simple interfaces)
-- [ ] Apply SOLID principles where natural
-- [ ] Consider what new code reveals about existing code
-- [ ] Run tests after each refactor step
+Dispatch **one** `Agent` call, `type: general-purpose`. Everything the subagent needs goes **inline in the prompt** — nothing new is written to disk:
 
-**Never refactor while RED.** Get to GREEN first.
+- The agreed user stories.
+- The full Given-When-Then scenario list from Step 1, in order.
+- The confirmed interface changes.
+- The path(s) to the failing tracer bullet test file(s) from Step 3, and the command that runs the test suite.
+- The loop rules, verbatim:
+  - Work one scenario at a time, in order. RED: write the next test → it fails. GREEN: write the minimal code to pass it → it passes.
+  - Only enough code to pass the current test. Don't anticipate later scenarios.
+  - Test observable behaviour through the public interface, not internals.
+  - Never refactor while RED — get to GREEN first.
+  - After every scenario is green, refactor (checklist below), running the full suite after each step.
+- The per-cycle checklist, for the subagent to apply to every scenario:
+  - Test name uses domain vocabulary, not implementation terms
+  - Test maps to a Given-When-Then scenario or acceptance criterion
+  - Test describes behaviour, not implementation
+  - Test uses the public interface only
+  - Test would survive an internal refactor
+  - Code is minimal for this test
+  - No speculative features added
+- The refactor checklist, to apply once green (see `refactoring.md`):
+  - Extract duplication
+  - Deepen modules (move complexity behind simple interfaces)
+  - Apply SOLID principles where natural
+  - Consider what new code reveals about existing code
+- Pointers, by path, for depth: `tests.md`, `mocking.md`, `refactoring.md` in the skill directory.
+- An explicit instruction: **do not re-invoke the `bdd` skill** — it would recurse.
+- A request to report back: for each scenario, whether it is green or could not be satisfied (and why); the refactors applied; and the final full test-run output.
 
-## Checklist Per Cycle
+If the subagent reports a scenario it could not satisfy, it stops there. The main context decides what to do next — fix it inline, or re-dispatch a fresh subagent with a narrower brief. There is no automatic retry loop.
 
-```text
-[ ] Test name uses domain vocabulary, not implementation terms
-[ ] Test maps to a Given-When-Then scenario or acceptance criterion
-[ ] Test describes behavior, not implementation
-[ ] Test uses public interface only
-[ ] Test would survive internal refactor
-[ ] Code is minimal for this test
-[ ] No speculative features added
-```
+## Step 5 — Verify the returned work
+
+Back in the main context, check the subagent's report:
+
+- [ ] Every scenario from Step 1 has a corresponding test, and the full suite is green
+- [ ] Each test uses domain vocabulary and maps to a Given-When-Then scenario
+- [ ] Tests exercise observable behaviour through the public interface — they would survive an internal refactor
+- [ ] No speculative features beyond the agreed scenarios
+- [ ] The refactors applied are sound and the suite is still green after them
+
+If anything fails the check, address it in the main context or re-dispatch a subagent.
+
+`pre-commit-check` and the commit are the caller's responsibility — under `/implement` they are Step 6's next actions, run once this skill returns.


### PR DESCRIPTION
## Summary

Splits the `behaviour-driven-development` workflow at a context boundary so the
implementation loop starts from a clean context, treating the agreed tests as its
specification.

- **Test-authoring phase** (main context): Three Amigos → agreed Given-When-Then
  scenario list → write only the first scenario's tracer bullet test (RED),
  confirming it fails for the right reason. No production code here.
- **Implementation phase** (fresh `general-purpose` subagent): receives the scenario
  list, interface changes, loop rules and the failing tracer test path inline; runs
  the vertical red-green-refactor loop one scenario at a time; reports back.
- **Verification** (main context): checks the returned work against the per-cycle
  checklist; `pre-commit-check` and commit stay with the caller.

The "Anti-Pattern: Horizontal Slices" prohibition is kept verbatim, with an additive
clarification and a diagram tweak: exactly one failing test crosses the boundary, and
the subagent still writes every remaining test one at a time.

Files: `behaviour-driven-development/SKILL.md`, `behaviour-driven-development/WORKFLOW.md`,
`.agent-docs/context.md` (glossary), plus the spec and issue artifacts.

Closes #71.

## Test plan

- No executable tests in this repo; skills are prose. Verified by read-through against
  the issue #71 acceptance criteria and two consecutive clean two-axis code-review
  passes (Standards + Spec).
- `pre-commit run` clean on all changed files and `--all-files`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)