### PR TITLE
chore: add uv support to the update-dependencies skill

### DIFF
--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -139,7 +139,7 @@ The process of syncing a target repo with `main`/`master` (to absorb changes Dep
 _Avoid_: dependency bump, package update, dependency refresh
 
 **Ecosystem** (dependency update sense):
-A language/package-manager combination detected in a target repo via marker files (e.g. `pyproject.toml` → Poetry, `uv.lock` (or `pyproject.toml` `[tool.uv]`) → uv, `package.json` + lockfile → npm/yarn/pnpm, `*.csproj`/`*.sln` → dotnet/NuGet). A single repo may have more than one.
+A language/package-manager combination detected in a target repo via marker files (e.g. `pyproject.toml` → Poetry, `uv.lock` → uv, `package.json` + lockfile → npm/yarn/pnpm, `*.csproj`/`*.sln` → dotnet/NuGet). A single repo may have more than one.
 _Avoid_: stack, toolchain, language target
 
 ### Diff Examination

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -139,7 +139,7 @@ The process of syncing a target repo with `main`/`master` (to absorb changes Dep
 _Avoid_: dependency bump, package update, dependency refresh
 
 **Ecosystem** (dependency update sense):
-A language/package-manager combination detected in a target repo via marker files (e.g. `pyproject.toml` → Poetry, `package.json` + lockfile → npm/yarn/pnpm, `*.csproj`/`*.sln` → dotnet/NuGet). A single repo may have more than one.
+A language/package-manager combination detected in a target repo via marker files (e.g. `uv.lock` or `pyproject.toml` `[tool.uv]` → uv, `pyproject.toml` `[tool.poetry]` → Poetry, `package.json` + lockfile → npm/yarn/pnpm, `*.csproj`/`*.sln` → dotnet/NuGet). A single repo may have more than one.
 _Avoid_: stack, toolchain, language target
 
 ### Diff Examination

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -139,7 +139,7 @@ The process of syncing a target repo with `main`/`master` (to absorb changes Dep
 _Avoid_: dependency bump, package update, dependency refresh
 
 **Ecosystem** (dependency update sense):
-A language/package-manager combination detected in a target repo via marker files (e.g. `uv.lock` or `pyproject.toml` `[tool.uv]` → uv, `pyproject.toml` → Poetry, `package.json` + lockfile → npm/yarn/pnpm, `*.csproj`/`*.sln` → dotnet/NuGet). A single repo may have more than one.
+A language/package-manager combination detected in a target repo via marker files (e.g. `pyproject.toml` → Poetry, `uv.lock` (or `pyproject.toml` `[tool.uv]`) → uv, `package.json` + lockfile → npm/yarn/pnpm, `*.csproj`/`*.sln` → dotnet/NuGet). A single repo may have more than one.
 _Avoid_: stack, toolchain, language target
 
 ### Diff Examination

--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -139,7 +139,7 @@ The process of syncing a target repo with `main`/`master` (to absorb changes Dep
 _Avoid_: dependency bump, package update, dependency refresh
 
 **Ecosystem** (dependency update sense):
-A language/package-manager combination detected in a target repo via marker files (e.g. `uv.lock` or `pyproject.toml` `[tool.uv]` → uv, `pyproject.toml` `[tool.poetry]` → Poetry, `package.json` + lockfile → npm/yarn/pnpm, `*.csproj`/`*.sln` → dotnet/NuGet). A single repo may have more than one.
+A language/package-manager combination detected in a target repo via marker files (e.g. `uv.lock` or `pyproject.toml` `[tool.uv]` → uv, `pyproject.toml` → Poetry, `package.json` + lockfile → npm/yarn/pnpm, `*.csproj`/`*.sln` → dotnet/NuGet). A single repo may have more than one.
 _Avoid_: stack, toolchain, language target
 
 ### Diff Examination

--- a/.agent-docs/issues/chore/uv-support-update-dependencies.md
+++ b/.agent-docs/issues/chore/uv-support-update-dependencies.md
@@ -1,0 +1,47 @@
+# Issues: chore/uv-support-update-dependencies
+
+## Add uv as a recognised Python manager in update-dependencies (#73)
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3, 4, 5, 6
+
+### What to build
+
+Add `uv` as a first-class Python manager alongside Poetry, PDM, Pipenv, and pip in the
+`update-dependencies` skill:
+
+- A `Python (uv)` row in the REFERENCE.md Detection Table (marker: `uv.lock`, or
+  `pyproject.toml` with `[tool.uv]`).
+- A precedence note directly under the Detection Table spelling out the full Python manager
+  fallback order, with `uv.lock` taking priority over any other tool table in
+  `pyproject.toml`.
+- A `uv` command subsection in REFERENCE.md's `## Python` section, placed first (before
+  Poetry): `uv lock --upgrade` → `uv sync` → `uv tree --outdated` (noting the
+  `uv pip list --outdated` fallback), with prose mirroring the Poetry entry's
+  constraint-bound-bump / report-majors framing, plus a line on non-blocking `uv sync`
+  failure handling.
+- A `uv run pytest` note added to the Validation Commands table's Python row.
+- SKILL.md Step 3's Python bullet updated to list uv; Step 6's staging example list updated
+  to include `uv.lock`.
+- `.agent-docs/context.md` Ecosystem entry updated to mention uv markers (already done
+  inline during the grill session — this issue just needs to carry that edit through).
+
+No control-flow change to any existing step; no change to the Poetry/PDM/Pipenv/pip flows.
+
+### Acceptance criteria
+
+- [ ] Detection Table has a `Python (uv)` row with the correct marker files.
+- [ ] Precedence note states uv.lock wins, and gives the full fallback order
+      (poetry → pdm → tool.uv → Pipfile → requirements.txt).
+- [ ] `uv` command subsection appears first in `## Python`, before Poetry, with the
+      `uv lock --upgrade` / `uv sync` / `uv tree --outdated` sequence and the `uv sync`
+      failure-handling line.
+- [ ] Validation Commands table's Python row mentions `uv run pytest`.
+- [ ] SKILL.md Step 3 Python bullet and Step 6 staging example list both mention uv/`uv.lock`.
+- [ ] `.agent-docs/context.md` Ecosystem entry mentions uv markers.
+- [ ] `pre-commit run --all-files` passes on the changed files.
+- [ ] No wording or command changes to the existing Poetry/PDM/Pipenv/pip/.NET/Node
+      sections.
+
+---

--- a/.agent-docs/issues/chore/uv-support-update-dependencies.md
+++ b/.agent-docs/issues/chore/uv-support-update-dependencies.md
@@ -1,5 +1,7 @@
 # Issues: chore/uv-support-update-dependencies
 
+> Work complete — PR ready to merge.
+
 ## Add uv as a recognised Python manager in update-dependencies (#73)
 
 **Blocked by**: None
@@ -31,17 +33,17 @@ No control-flow change to any existing step; no change to the Poetry/PDM/Pipenv/
 
 ### Acceptance criteria
 
-- [ ] Detection Table has a `Python (uv)` row with the correct marker files.
-- [ ] Precedence note states uv.lock wins, and gives the full fallback order
+- [x] Detection Table has a `Python (uv)` row with the correct marker files.
+- [x] Precedence note states uv.lock wins, and gives the full fallback order
       (poetry → pdm → tool.uv → Pipfile → requirements.txt).
-- [ ] `uv` command subsection appears first in `## Python`, before Poetry, with the
+- [x] `uv` command subsection appears first in `## Python`, before Poetry, with the
       `uv lock --upgrade` / `uv sync` / `uv tree --outdated` sequence and the `uv sync`
       failure-handling line.
-- [ ] Validation Commands table's Python row mentions `uv run pytest`.
-- [ ] SKILL.md Step 3 Python bullet and Step 6 staging example list both mention uv/`uv.lock`.
-- [ ] `.agent-docs/context.md` Ecosystem entry mentions uv markers.
-- [ ] `pre-commit run --all-files` passes on the changed files.
-- [ ] No wording or command changes to the existing Poetry/PDM/Pipenv/pip/.NET/Node
+- [x] Validation Commands table's Python row mentions `uv run pytest`.
+- [x] SKILL.md Step 3 Python bullet and Step 6 staging example list both mention uv/`uv.lock`.
+- [x] `.agent-docs/context.md` Ecosystem entry mentions uv markers.
+- [x] `pre-commit run --all-files` passes on the changed files.
+- [x] No wording or command changes to the existing Poetry/PDM/Pipenv/pip/.NET/Node
       sections.
 
 ---

--- a/.agent-docs/specs/chore/uv-support-update-dependencies.md
+++ b/.agent-docs/specs/chore/uv-support-update-dependencies.md
@@ -59,7 +59,8 @@ non-uv repo.
   `uv.lock` is present, use the uv flow for that directory and skip the other Python flows
   there, even when `pyproject.toml` also has `[tool.poetry]` or `[tool.pdm]`; with no
   `uv.lock`, fall back in this order: `[tool.poetry]` → `[tool.pdm]` → `[tool.uv]` →
-  `Pipfile` → `requirements.txt`. This makes the previously-implicit ordering explicit as a
+  `Pipfile` → `requirements.txt` (with `requirements.in` present selecting the pip-tools
+  flow, per the Detection Table). This makes the previously-implicit ordering explicit as a
   side benefit.
 - **`uv` command subsection** (`REFERENCE.md` `## Python`) — placed **first**, before the
   Poetry entry, mirroring the Detection Table row order. Its header condition ends

--- a/.agent-docs/specs/chore/uv-support-update-dependencies.md
+++ b/.agent-docs/specs/chore/uv-support-update-dependencies.md
@@ -69,10 +69,12 @@ non-uv repo.
   dependency that isn't held at an exact version to the newest version the `pyproject.toml`
   constraints allow and rewrites `uv.lock`; `uv sync` reconciles the environment; with
   normal constraints this is patch/minor only; anything `uv tree --outdated` still shows
-  behind is constraint-bound — report as a major bump candidate, do not widen the
-  constraint. Adds one skill-specific line: if `uv sync` fails on a resolution conflict from
-  the upgrade, record it in the report and carry on — do not revert or block the commit
-  (consistent with the skill's best-effort, non-blocking posture).
+  behind is constraint-bound (a direct `pyproject.toml` constraint or a transitive
+  requirement) — report as a major bump candidate, don't widen a `pyproject.toml`
+  constraint to chase it. Adds one skill-specific line: if `uv lock --upgrade` or `uv sync`
+  fails (resolution conflict, no network, unsatisfiable constraint), record it in the report
+  and carry on — do not revert or block the commit (consistent with the skill's best-effort,
+  non-blocking posture).
 - **Validation Commands table** (`REFERENCE.md`) — the Python row gains a parenthetical:
   `pytest` (for a uv project, `uv run pytest`) if a `tests/` dir or a `pytest` dependency is
   present, else skip.
@@ -81,10 +83,10 @@ non-uv repo.
 - **SKILL.md Step 6** — the staging-example parenthetical gains `uv.lock` alongside
   `poetry.lock`.
 - **`.agent-docs/context.md`** — the **Ecosystem** entry's marker examples gain
-  "`uv.lock` (or `pyproject.toml` `[tool.uv]`) → uv", inserted after the existing
-  `pyproject.toml` → Poetry example so the glossary order doesn't imply uv wins over Poetry
-  (the no-lockfile fallback in REFERENCE.md puts `[tool.poetry]` first). Done inline during
-  the grill session.
+  "`uv.lock` → uv", inserted after the existing `pyproject.toml` → Poetry example. Only the
+  unambiguous `uv.lock` marker is listed in the glossary; the `[tool.uv]`-without-lockfile
+  case is left to the precedence note in REFERENCE.md, which is the canonical place for
+  resolution order. Done inline during the grill session.
 - No change to any step's control flow beyond naming uv as a detected manager. The existing
   Step 3 rule "if a required package manager binary isn't installed for a detected
   ecosystem, report and skip" already covers a missing `uv` on `PATH` with no new text.

--- a/.agent-docs/specs/chore/uv-support-update-dependencies.md
+++ b/.agent-docs/specs/chore/uv-support-update-dependencies.md
@@ -63,9 +63,10 @@ non-uv repo.
   side benefit.
 - **`uv` command subsection** (`REFERENCE.md` `## Python`) — placed **first**, before the
   Poetry entry, mirroring the Detection Table row order. Command sequence:
-  `uv lock --upgrade` → `uv sync` → `uv tree --outdated` (with a noted fallback to
-  `uv pip list --outdated` on older uv without the flag). Prose mirrors the Poetry entry:
-  `uv lock --upgrade` moves each dependency to the newest version the `pyproject.toml`
+  `uv lock --upgrade` → `uv sync` → `uv tree --outdated` (with a concrete fallback: if
+  `uv tree --outdated` exits non-zero on an older uv without the flag, use
+  `uv pip list --outdated`). Prose mirrors the Poetry entry: `uv lock --upgrade` moves each
+  dependency that isn't held at an exact version to the newest version the `pyproject.toml`
   constraints allow and rewrites `uv.lock`; `uv sync` reconciles the environment; with
   normal constraints this is patch/minor only; anything `uv tree --outdated` still shows
   behind is constraint-bound — report as a major bump candidate, do not widen the
@@ -80,7 +81,10 @@ non-uv repo.
 - **SKILL.md Step 6** — the staging-example parenthetical gains `uv.lock` alongside
   `poetry.lock`.
 - **`.agent-docs/context.md`** — the **Ecosystem** entry's marker examples gain
-  "`uv.lock` or `pyproject.toml` `[tool.uv]` → uv" (done inline during the grill session).
+  "`uv.lock` (or `pyproject.toml` `[tool.uv]`) → uv", inserted after the existing
+  `pyproject.toml` → Poetry example so the glossary order doesn't imply uv wins over Poetry
+  (the no-lockfile fallback in REFERENCE.md puts `[tool.poetry]` first). Done inline during
+  the grill session.
 - No change to any step's control flow beyond naming uv as a detected manager. The existing
   Step 3 rule "if a required package manager binary isn't installed for a detected
   ecosystem, report and skip" already covers a missing `uv` on `PATH` with no new text.

--- a/.agent-docs/specs/chore/uv-support-update-dependencies.md
+++ b/.agent-docs/specs/chore/uv-support-update-dependencies.md
@@ -62,7 +62,11 @@ non-uv repo.
   `Pipfile` → `requirements.txt`. This makes the previously-implicit ordering explicit as a
   side benefit.
 - **`uv` command subsection** (`REFERENCE.md` `## Python`) — placed **first**, before the
-  Poetry entry, mirroring the Detection Table row order. Command sequence:
+  Poetry entry, mirroring the Detection Table row order. Its header condition ends
+  "— subject to the precedence note above" so the bare `[tool.uv]` marker can't be read as
+  "uv wins whenever `[tool.uv]` exists"; it points at the note rather than restating its
+  fallback order, keeping symmetry with the bare Poetry/PDM/Pipenv headers. Command
+  sequence:
   `uv lock --upgrade` → `uv sync` → `uv tree --outdated` (with a concrete fallback: if
   `uv tree --outdated` exits non-zero on an older uv without the flag, use
   `uv pip list --outdated`). Prose mirrors the Poetry entry: `uv lock --upgrade` moves each

--- a/.agent-docs/specs/chore/uv-support-update-dependencies.md
+++ b/.agent-docs/specs/chore/uv-support-update-dependencies.md
@@ -1,0 +1,116 @@
+# Add uv Support to the update-dependencies Skill
+
+## Problem Statement
+
+The `update-dependencies` skill documents four Python managers — Poetry, PDM, Pipenv, and
+pip — but not [uv](https://docs.astral.sh/uv/), which has become a mainstream Python package
+manager and is increasingly the only lockfile a new project ships. When the skill is run
+against a uv repo today, one of two things goes wrong:
+
+- If `pyproject.toml` also carries a `[tool.poetry]` or `[tool.pdm]` table (common when uv
+  is adopted for locking while older tool config lingers), the skill runs the wrong
+  manager's commands.
+- If `pyproject.toml` is PEP 621-only with just a `uv.lock` beside it, no Detection Table
+  row matches and the repo is not recognised as Python at all.
+
+Either way the user gets no uv dependency bump from a skill whose whole job is to bump
+dependencies across every detected ecosystem.
+
+## Solution
+
+Treat uv as a first-class Python **manager** within the existing Python **ecosystem**: add a
+Detection Table row, a precedence rule that disambiguates a multi-tool `pyproject.toml`, a
+`uv` command subsection mirroring the Poetry entry's shape, and a validation-command note.
+The skill then detects a uv repo, runs `uv lock --upgrade` + `uv sync` to bump within the
+`pyproject.toml` constraints, lists still-outdated packages as major-bump candidates for the
+report, and stages `uv.lock` in the local commit — with no behavioural change for any
+non-uv repo.
+
+## User Stories
+
+1. As a developer running `/update-dependencies` against a repo locked with uv, I want the
+   skill to recognise the uv ecosystem and run `uv lock --upgrade` + `uv sync`, so that my
+   uv dependencies get the same patch/minor bump the other ecosystems already get.
+2. As a developer whose `pyproject.toml` carries both `[tool.poetry]` (metadata) and a
+   `uv.lock`, I want a documented precedence rule that picks uv, so that the skill does not
+   run `poetry update` against a uv-managed project.
+3. As a developer whose `pyproject.toml` is PEP 621-only with a `uv.lock` beside it, I want
+   that combination detected as Python, so that the repo is not silently reported as "no
+   known ecosystem".
+4. As a developer reading the run report, I want packages that uv could not advance to
+   latest (held back by a `pyproject.toml` constraint) listed as major-bump candidates, so
+   that I know what a manual constraint change would unlock — consistent with how Poetry and
+   npm results are reported.
+5. As a developer reviewing the local commit, I want `uv.lock` (and `pyproject.toml` if the
+   upgrade touched it) staged and nothing else, so that the commit matches the skill's
+   existing "only stage what this run touched" rule.
+6. As an agent maintaining `.agent-docs/context.md`, I want the Ecosystem glossary entry's
+   marker examples to mention uv, so that the domain vocabulary stays in step with the
+   skill.
+
+## Implementation Decisions
+
+- Files touched: `update-dependencies/REFERENCE.md`, `update-dependencies/SKILL.md`,
+  `.agent-docs/context.md`.
+- **Detection Table** (`REFERENCE.md`) — add a `Python (uv)` row: marker files
+  `uv.lock`, or `pyproject.toml` with `[tool.uv]`; "Manager selected by" = `—`.
+- **Python manager precedence note** (`REFERENCE.md`) — new paragraph immediately after the
+  "check one level of subdirectories" paragraph under the Detection Table. States: if
+  `uv.lock` is present, use the uv flow for that directory and skip the other Python flows
+  there, even when `pyproject.toml` also has `[tool.poetry]` or `[tool.pdm]`; with no
+  `uv.lock`, match in table order `[tool.poetry]` → `[tool.pdm]` → `[tool.uv]` → `Pipfile`
+  → `requirements.txt`. This makes the previously-implicit ordering explicit as a side
+  benefit.
+- **`uv` command subsection** (`REFERENCE.md` `## Python`) — placed **first**, before the
+  Poetry entry, mirroring the Detection Table row order. Command sequence:
+  `uv lock --upgrade` → `uv sync` → `uv tree --outdated` (with a noted fallback to
+  `uv pip list --outdated` on older uv without the flag). Prose mirrors the Poetry entry:
+  `uv lock --upgrade` moves each dependency to the newest version the `pyproject.toml`
+  constraints allow and rewrites `uv.lock`; `uv sync` reconciles the environment; with
+  normal constraints this is patch/minor only; anything `uv tree --outdated` still shows
+  behind is constraint-bound — report as a major bump candidate, do not widen the
+  constraint. Adds one skill-specific line: if `uv sync` fails on a resolution conflict from
+  the upgrade, record it in the report and carry on — do not revert or block the commit
+  (consistent with the skill's best-effort, non-blocking posture).
+- **Validation Commands table** (`REFERENCE.md`) — the Python row gains a parenthetical:
+  `pytest` (for a uv project, `uv run pytest`) if a `tests/` dir or a `pytest` dependency is
+  present, else skip.
+- **SKILL.md Step 3** — the Python bullet becomes "uv, Poetry, PDM, Pipenv, or pip, selected
+  by marker file."
+- **SKILL.md Step 6** — the staging-example parenthetical gains `uv.lock` alongside
+  `poetry.lock`.
+- **`.agent-docs/context.md`** — the **Ecosystem** entry's marker examples gain
+  "`uv.lock` or `pyproject.toml` `[tool.uv]` → uv" (done inline during the grill session).
+- No change to any step's control flow beyond naming uv as a detected manager. The existing
+  Step 3 rule "if a required package manager binary isn't installed for a detected
+  ecosystem, report and skip" already covers a missing `uv` on `PATH` with no new text.
+
+## Testing Decisions
+
+- No executable code changes, so no unit tests and no BDD red-green loop — the BDD step for
+  this slice is the edit plus `pre-commit-check` plus commit.
+- Verification seams:
+  1. `pre-commit run --all-files` passes (markdown formatting / repo linters).
+  2. Read-through: the Detection row, precedence note, and `uv` subsection are internally
+     consistent with the existing table order and copy-pasteable.
+  3. `code-review` Spec axis confirms the change matches this spec.
+- Prior art: `chore/gh-jq-arg-pitfall-doc` and `chore/python-c-windows-note` are recent
+  documentation-only slices verified the same way.
+
+## Out of Scope
+
+- uv as a pre-commit hook language accelerator — Step 4 stays `pre-commit autoupdate` as-is.
+- `uv tool` / `uv self` upgrades (globally installed uv tools or uv itself).
+- Installing uv when it is absent — the existing report-and-skip rule covers it.
+- `uv pip compile` of a `requirements.in` — the pip-tools entry stays the documented path.
+- Special handling of dependency groups / extras — `uv lock --upgrade` covers all groups by
+  default.
+- Any behavioural change to the Poetry / PDM / Pipenv / pip flows.
+
+## Further Notes
+
+- uv subsection ordering (first, before Poetry) and the precedence note's full-ordering form
+  were both explicitly chosen during the grill session over the narrower alternatives.
+- A stale local branch `chore/update-dependencies-uv-support` exists from an earlier aborted
+  attempt (unpushed, no commits beyond `origin/main`); it is checked out in the main
+  worktree and should be deleted there once this work lands.

--- a/.agent-docs/specs/chore/uv-support-update-dependencies.md
+++ b/.agent-docs/specs/chore/uv-support-update-dependencies.md
@@ -58,9 +58,9 @@ non-uv repo.
   "check one level of subdirectories" paragraph under the Detection Table. States: if
   `uv.lock` is present, use the uv flow for that directory and skip the other Python flows
   there, even when `pyproject.toml` also has `[tool.poetry]` or `[tool.pdm]`; with no
-  `uv.lock`, match in table order `[tool.poetry]` → `[tool.pdm]` → `[tool.uv]` → `Pipfile`
-  → `requirements.txt`. This makes the previously-implicit ordering explicit as a side
-  benefit.
+  `uv.lock`, fall back in this order: `[tool.poetry]` → `[tool.pdm]` → `[tool.uv]` →
+  `Pipfile` → `requirements.txt`. This makes the previously-implicit ordering explicit as a
+  side benefit.
 - **`uv` command subsection** (`REFERENCE.md` `## Python`) — placed **first**, before the
   Poetry entry, mirroring the Detection Table row order. Command sequence:
   `uv lock --upgrade` → `uv sync` → `uv tree --outdated` (with a noted fallback to

--- a/update-dependencies/REFERENCE.md
+++ b/update-dependencies/REFERENCE.md
@@ -28,7 +28,7 @@ uv sync
 uv tree --outdated   # if this exits non-zero (older uv without the flag), use `uv pip list --outdated`
 ```
 
-`uv lock --upgrade` moves each dependency that isn't held at an exact version to the newest version allowed by the constraints in `pyproject.toml`, rewriting `uv.lock`; `uv sync` reconciles the environment. With normal constraints (`>=x,<y`, `~=x.y`) this is patch/minor only. Anything `uv tree --outdated` still shows behind is held below latest by a `pyproject.toml` constraint — report it as a major bump candidate; do not widen the constraint. If `uv sync` fails on a resolution conflict from the upgrade, record it in the report and carry on — do not revert or block the commit.
+`uv lock --upgrade` moves each dependency that isn't held at an exact version to the newest version allowed by the constraints in `pyproject.toml`, rewriting `uv.lock`; `uv sync` reconciles the environment. With normal constraints (`>=x,<y`, `~=x.y`) this is patch/minor only. Anything `uv tree --outdated` still shows behind is held below latest by a constraint — a direct one in `pyproject.toml` or a transitive dependency's requirement — so report it as a major bump candidate; don't widen a `pyproject.toml` constraint to chase it. If `uv lock --upgrade` or `uv sync` fails (resolution conflict, no network, unsatisfiable constraint), record it in the report and carry on — do not revert or block the commit.
 
 **Poetry** (`pyproject.toml` has `[tool.poetry]`):
 

--- a/update-dependencies/REFERENCE.md
+++ b/update-dependencies/REFERENCE.md
@@ -16,7 +16,7 @@ Detection rules, per-ecosystem commands, and validation commands. Workflow steps
 
 Check the repo root first. For monorepos, also check one level of subdirectories (e.g. `packages/*`, `services/*`) and run each ecosystem's flow per matching directory.
 
-**Python manager precedence:** if `uv.lock` is present, use the uv flow for that directory and skip the other Python flows there, even when `pyproject.toml` also has `[tool.poetry]` or `[tool.pdm]`. With no `uv.lock`, fall back in this order: `[tool.poetry]` → `[tool.pdm]` → `[tool.uv]` → `Pipfile` → `requirements.txt`.
+**Python manager precedence:** if `uv.lock` is present, use the uv flow for that directory and skip the other Python flows there, even when `pyproject.toml` also has `[tool.poetry]` or `[tool.pdm]`. With no `uv.lock`, fall back in this order: `[tool.poetry]` → `[tool.pdm]` → `[tool.uv]` → `Pipfile` → `requirements.txt` (with `requirements.in` present selecting the pip-tools flow, per the Detection Table).
 
 ## Python
 

--- a/update-dependencies/REFERENCE.md
+++ b/update-dependencies/REFERENCE.md
@@ -6,6 +6,7 @@ Detection rules, per-ecosystem commands, and validation commands. Workflow steps
 
 | Ecosystem | Marker file(s) | Manager selected by |
 |---|---|---|
+| Python (uv) | `uv.lock`, or `pyproject.toml` with `[tool.uv]` | — |
 | Python (Poetry) | `pyproject.toml` with `[tool.poetry]` | — |
 | Python (PDM) | `pyproject.toml` with `[tool.pdm]` | — |
 | Python (Pipenv) | `Pipfile` | — |
@@ -15,7 +16,19 @@ Detection rules, per-ecosystem commands, and validation commands. Workflow steps
 
 Check the repo root first. For monorepos, also check one level of subdirectories (e.g. `packages/*`, `services/*`) and run each ecosystem's flow per matching directory.
 
+**Python manager precedence:** if `uv.lock` is present, use the uv flow for that directory and skip the other Python flows there, even when `pyproject.toml` also has `[tool.poetry]` or `[tool.pdm]`. With no `uv.lock`, match in table order: `[tool.poetry]` → `[tool.pdm]` → `[tool.uv]` → `Pipfile` → `requirements.txt`.
+
 ## Python
+
+**uv** (`uv.lock` present, or `pyproject.toml` has `[tool.uv]`):
+
+```bash
+uv lock --upgrade
+uv sync
+uv tree --outdated   # falls back to `uv pip list --outdated` on older uv without the flag
+```
+
+`uv lock --upgrade` moves every dependency to the newest version allowed by the constraints in `pyproject.toml`, rewriting `uv.lock`; `uv sync` reconciles the environment. With normal constraints (`>=x,<y`, `~=x.y`) this is patch/minor only. Anything `uv tree --outdated` still shows behind is held below latest by a `pyproject.toml` constraint — report it as a major bump candidate; do not widen the constraint. If `uv sync` fails on a resolution conflict from the upgrade, record it in the report and carry on — do not revert or block the commit.
 
 **Poetry** (`pyproject.toml` has `[tool.poetry]`):
 
@@ -124,7 +137,7 @@ Run if detectable; record pass/fail only — never block or revert on failure.
 
 | Ecosystem | Command |
 |---|---|
-| Python | `pytest` if a `tests/` dir or a `pytest` dependency is present, else skip |
+| Python | `pytest` (for a uv project, `uv run pytest`) if a `tests/` dir or a `pytest` dependency is present, else skip |
 | .NET | `dotnet build`, then `dotnet test` if a test project (e.g. `*.Tests.csproj`) exists |
 | Node | `npm test` / `yarn test` / `pnpm test` if a `test` script exists in `package.json`; else `npm run build` / equivalent if a `build` script exists |
 

--- a/update-dependencies/REFERENCE.md
+++ b/update-dependencies/REFERENCE.md
@@ -25,10 +25,10 @@ Check the repo root first. For monorepos, also check one level of subdirectories
 ```bash
 uv lock --upgrade
 uv sync
-uv tree --outdated   # falls back to `uv pip list --outdated` on older uv without the flag
+uv tree --outdated   # if this exits non-zero (older uv without the flag), use `uv pip list --outdated`
 ```
 
-`uv lock --upgrade` moves every dependency to the newest version allowed by the constraints in `pyproject.toml`, rewriting `uv.lock`; `uv sync` reconciles the environment. With normal constraints (`>=x,<y`, `~=x.y`) this is patch/minor only. Anything `uv tree --outdated` still shows behind is held below latest by a `pyproject.toml` constraint — report it as a major bump candidate; do not widen the constraint. If `uv sync` fails on a resolution conflict from the upgrade, record it in the report and carry on — do not revert or block the commit.
+`uv lock --upgrade` moves each dependency that isn't held at an exact version to the newest version allowed by the constraints in `pyproject.toml`, rewriting `uv.lock`; `uv sync` reconciles the environment. With normal constraints (`>=x,<y`, `~=x.y`) this is patch/minor only. Anything `uv tree --outdated` still shows behind is held below latest by a `pyproject.toml` constraint — report it as a major bump candidate; do not widen the constraint. If `uv sync` fails on a resolution conflict from the upgrade, record it in the report and carry on — do not revert or block the commit.
 
 **Poetry** (`pyproject.toml` has `[tool.poetry]`):
 

--- a/update-dependencies/REFERENCE.md
+++ b/update-dependencies/REFERENCE.md
@@ -16,7 +16,7 @@ Detection rules, per-ecosystem commands, and validation commands. Workflow steps
 
 Check the repo root first. For monorepos, also check one level of subdirectories (e.g. `packages/*`, `services/*`) and run each ecosystem's flow per matching directory.
 
-**Python manager precedence:** if `uv.lock` is present, use the uv flow for that directory and skip the other Python flows there, even when `pyproject.toml` also has `[tool.poetry]` or `[tool.pdm]`. With no `uv.lock`, match in table order: `[tool.poetry]` → `[tool.pdm]` → `[tool.uv]` → `Pipfile` → `requirements.txt`.
+**Python manager precedence:** if `uv.lock` is present, use the uv flow for that directory and skip the other Python flows there, even when `pyproject.toml` also has `[tool.poetry]` or `[tool.pdm]`. With no `uv.lock`, fall back in this order: `[tool.poetry]` → `[tool.pdm]` → `[tool.uv]` → `Pipfile` → `requirements.txt`.
 
 ## Python
 

--- a/update-dependencies/REFERENCE.md
+++ b/update-dependencies/REFERENCE.md
@@ -20,7 +20,7 @@ Check the repo root first. For monorepos, also check one level of subdirectories
 
 ## Python
 
-**uv** (`uv.lock` present, or `pyproject.toml` has `[tool.uv]`):
+**uv** (`uv.lock` present, or `pyproject.toml` has `[tool.uv]` — subject to the precedence note above):
 
 ```bash
 uv lock --upgrade

--- a/update-dependencies/SKILL.md
+++ b/update-dependencies/SKILL.md
@@ -28,7 +28,7 @@ If nothing matches, report that no known ecosystem was detected and give brief g
 
 For each detected ecosystem, follow its command sequence in [REFERENCE.md](REFERENCE.md):
 
-- **Python** — Poetry, PDM, Pipenv, or pip, selected by marker file.
+- **Python** — uv, Poetry, PDM, Pipenv, or pip, selected by marker file.
 - **.NET / C#** — `dotnet` CLI (covers any `.csproj`/`.sln`).
 - **Node / TypeScript / React** — npm, yarn, or pnpm, selected by lockfile.
 
@@ -49,7 +49,7 @@ For each ecosystem updated, run its standard build/test command if one is detect
 
 ## Step 6: Commit
 
-Stage only the files this run actually touched — dependency manifests, lockfiles, and `.pre-commit-config.yaml` (e.g. `package.json`, `package-lock.json`, `requirements.txt`, `poetry.lock`, `pyproject.toml`, `*.csproj`, `.pre-commit-config.yaml`). Never `git add -A` or `git add .`: a stash popped back in Step 1 may contain unrelated in-progress work that must not be bundled into this commit.
+Stage only the files this run actually touched — dependency manifests, lockfiles, and `.pre-commit-config.yaml` (e.g. `package.json`, `package-lock.json`, `requirements.txt`, `poetry.lock`, `uv.lock`, `pyproject.toml`, `*.csproj`, `.pre-commit-config.yaml`). Never `git add -A` or `git add .`: a stash popped back in Step 1 may contain unrelated in-progress work that must not be bundled into this commit.
 
 Commit with a clear, descriptive message summarizing what was updated per ecosystem, e.g.:
 


### PR DESCRIPTION
## Summary

Adds [uv](https://docs.astral.sh/uv/) as a first-class Python manager in the `update-dependencies` skill, alongside Poetry, PDM, Pipenv, and pip. Before this, a uv-locked repo either fell through to the wrong manager's commands (when `pyproject.toml` also carried a `[tool.poetry]`/`[tool.pdm]` table) or wasn't recognised as Python at all (PEP 621 `pyproject.toml` + `uv.lock` only).

Documentation-only change to the skill's instruction files — no executable code.

## Changes

- **`update-dependencies/REFERENCE.md`**
  - Detection Table gains a `Python (uv)` row (marker: `uv.lock`, or `pyproject.toml` with `[tool.uv]`).
  - New "Python manager precedence" note under the table: `uv.lock` present ⇒ uv flow wins; otherwise fall back `[tool.poetry]` → `[tool.pdm]` → `[tool.uv]` → `Pipfile` → `requirements.txt`.
  - New `uv` subsection at the top of `## Python` (before Poetry): `uv lock --upgrade` → `uv sync` → `uv tree --outdated` (with a concrete `uv pip list --outdated` fallback on non-zero exit), Poetry-mirrored constraint/major-bump framing, and a non-blocking failure-handling line for `uv lock --upgrade` / `uv sync`.
  - Validation Commands table's Python row notes `uv run pytest` for uv projects.
- **`update-dependencies/SKILL.md`** — Step 3 Python bullet lists uv; Step 6 staging examples include `uv.lock`.
- **`.agent-docs/context.md`** — Ecosystem glossary entry mentions the `uv.lock` marker.
- **`.agent-docs/specs/`, `.agent-docs/issues/`** — spec and issue for this slice (#73).

## Test plan

- `pre-commit run --all-files` passes.
- Two-axis `code-review` (Standards + Spec) run to two consecutive clean passes.
- No executable code, so no unit tests; the existing Poetry/PDM/Pipenv/pip/.NET/Node sections are unchanged.

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)