### PR TITLE
bugfix: select the sync interpreter by execution, not command -v

### DIFF
--- a/.agent-docs/issues/bugfix/sync-hook-interpreter-selection.md
+++ b/.agent-docs/issues/bugfix/sync-hook-interpreter-selection.md
@@ -1,0 +1,50 @@
+# Issues: bugfix/sync-hook-interpreter-selection
+
+## Select the sync interpreter by execution, not `command -v` (#75)
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3, 4, 5, 6
+
+### What to build
+
+Both `.pre-commit-config.yaml`'s `sync-claude-skills` hook entry and `bin/update-skills`'s
+`sys_py` loop choose a Python interpreter by testing existence on `PATH` (`command -v`) or
+on disk (`[ -f ]`). The Windows Store `python3` App Execution Alias passes those tests but
+exits non-zero, so the wrong interpreter gets picked and the sync (or `.venv` creation)
+fails.
+
+Change both sites to pick the first candidate that actually **runs**
+(`"$py" -c "" >/dev/null 2>&1`), keeping the candidate order
+(`.venv/Scripts/python[.exe]` → `.venv/bin/python` → `python3` → `python`) exactly as it is.
+
+- `.pre-commit-config.yaml`: rewrite the `entry` as an inline `bash -c` loop over the
+  candidates, `exec`-ing the first that runs, and `echo`ing a one-line error + `exit 1` if
+  none do. Stays inline (no new script file). One `#` comment above the hook explaining
+  why selection is by execution.
+- `bin/update-skills`: hoist the existing `runs_ok()` helper above the interpreter-resolution
+  block and use it in the `sys_py` loop instead of `command -v`. Reword the follow-on `die`
+  message from "no python3 or python on PATH" to "no working python3 or python found". One
+  comment on the loop mirroring the hook's.
+
+No change to candidate precedence, the pre-commit/post-commit split, `pick_venv_py`, or
+`sync_claude_skills.py`. ADR 0005 is not part of this issue.
+
+### Acceptance criteria
+
+- [ ] `.pre-commit-config.yaml` `sync-claude-skills` `entry` selects the interpreter with
+      `"$py" -c "" >/dev/null 2>&1`, not `command -v` / `[ -f ]`; candidate order unchanged;
+      `exec`s the chosen interpreter.
+- [ ] When no candidate runs, the hook prints `sync-claude-skills: no working python
+      interpreter found` (or equivalent one-liner) to stderr and exits non-zero.
+- [ ] On this machine (Store `python3` stub, no `.venv`): a real `git commit` on the branch
+      triggers the `post-commit` hook, it runs the sync via `python`, exits 0 with no stub
+      error, and `~/.claude/skills` is updated.
+- [ ] `bin/update-skills` `sys_py` loop uses `runs_ok`; the "cannot create .venv" `die`
+      message names *working* Python.
+- [ ] A one-line rationale comment is present at both call sites.
+- [ ] `pre-commit run --all-files` passes; `shellcheck` is clean on `bin/update-skills`.
+- [ ] No behavioural change when a real `.venv` or a working `python3` is present (earlier
+      candidate still wins).
+
+---

--- a/.agent-docs/issues/bugfix/sync-hook-interpreter-selection.md
+++ b/.agent-docs/issues/bugfix/sync-hook-interpreter-selection.md
@@ -1,5 +1,7 @@
 # Issues: bugfix/sync-hook-interpreter-selection
 
+> Work complete — PR ready to merge.
+
 ## Select the sync interpreter by execution, not `command -v` (#75)
 
 **Blocked by**: None
@@ -32,19 +34,19 @@ No change to candidate precedence, the pre-commit/post-commit split, `pick_venv_
 
 ### Acceptance criteria
 
-- [ ] `.pre-commit-config.yaml` `sync-claude-skills` `entry` selects the interpreter with
+- [x] `.pre-commit-config.yaml` `sync-claude-skills` `entry` selects the interpreter with
       `"$py" -c "" >/dev/null 2>&1`, not `command -v` / `[ -f ]`; candidate order unchanged;
       `exec`s the chosen interpreter.
-- [ ] When no candidate runs, the hook prints `sync-claude-skills: no working python
+- [x] When no candidate runs, the hook prints `sync-claude-skills: no working python
       interpreter found` (or equivalent one-liner) to stderr and exits non-zero.
-- [ ] On this machine (Store `python3` stub, no `.venv`): a real `git commit` on the branch
+- [x] On this machine (Store `python3` stub, no `.venv`): a real `git commit` on the branch
       triggers the `post-commit` hook, it runs the sync via `python`, exits 0 with no stub
       error, and `~/.claude/skills` is updated.
-- [ ] `bin/update-skills` `sys_py` loop uses `runs_ok`; the "cannot create .venv" `die`
+- [x] `bin/update-skills` `sys_py` loop uses `runs_ok`; the "cannot create .venv" `die`
       message names *working* Python.
-- [ ] A one-line rationale comment is present at both call sites.
-- [ ] `pre-commit run --all-files` passes; `shellcheck` is clean on `bin/update-skills`.
-- [ ] No behavioural change when a real `.venv` or a working `python3` is present (earlier
+- [x] A one-line rationale comment is present at both call sites.
+- [x] `pre-commit run --all-files` passes; `shellcheck` is clean on `bin/update-skills`.
+- [x] No behavioural change when a real `.venv` or a working `python3` is present (earlier
       candidate still wins).
 
 ---

--- a/.agent-docs/specs/bugfix/sync-hook-interpreter-selection.md
+++ b/.agent-docs/specs/bugfix/sync-hook-interpreter-selection.md
@@ -1,0 +1,115 @@
+# Fix sync-claude-skills interpreter selection (Windows Store python3 stub)
+
+## Problem Statement
+
+On a fresh Windows install, `python3` resolves to the Microsoft Store "App Execution
+Alias" — a real executable on `PATH` (`%LOCALAPPDATA%\Microsoft\WindowsApps\python3`) that
+does nothing but print "Python was not found..." and exit non-zero.
+
+Two places in this repo choose a Python interpreter by testing **existence on `PATH`**, not
+**whether it runs**:
+
+- `.pre-commit-config.yaml`, the `sync-claude-skills` `post-commit` hook `entry`: its
+  fallback chain reaches `elif command -v python3 >/dev/null 2>&1; then python3 ...`. On this
+  machine `command -v python3` succeeds (the stub is a real file), so the hook runs
+  `python3 sync_claude_skills.py`, which fails with exit 49.
+- `bin/update-skills`, the `sys_py` loop: `for candidate in python3 python; do if command -v
+  "$candidate" ...; then sys_py="$candidate"; break; fi; done` — same test, same wrong pick.
+  `sys_py` is only used to *create* `.venv`, so on a machine that already has a working
+  `.venv` this is latent, but on a fresh clone `"$sys_py" -m venv .venv` fails.
+
+User-visible effect: every `git commit` in the repo prints the `python3` stub error, and the
+`post-commit` sync silently does not run, so `~/.claude/skills` drifts stale from the repo
+without the committer noticing. (This is exactly what happened while shipping the uv-support
+change earlier — it did not propagate to the installed skills.)
+
+## Solution
+
+Select the interpreter by **running** each candidate (`"$py" -c '' >/dev/null 2>&1`) instead
+of by `command -v` / `[ -f ]`. A stub that exits non-zero is skipped; the loop falls through
+to the next candidate. Candidate order is unchanged
+(`.venv/Scripts/python[.exe]` → `.venv/bin/python` → `python3` → `python`). `bin/update-skills`
+already contains exactly the right test as its `runs_ok()` helper — it is simply not applied
+to `sys_py` selection.
+
+If no candidate runs, the hook fails loudly (one-line stderr message, non-zero exit) rather
+than skipping silently.
+
+## User Stories
+
+1. As someone committing to the skills repo on a Windows machine with no python.org Python
+   installed, I want `git commit` to finish without a `python3` stub error, so that the
+   commit output is clean.
+2. As that same person, I want the `post-commit` sync to actually run (via whatever Python
+   does work), so that `~/.claude/skills` stays current with the repo automatically.
+3. As someone cloning the repo fresh on that machine and running `update-skills`, I want
+   `.venv` creation to use a Python that runs, so that first-run bootstrap succeeds.
+4. As someone on a healthy setup (real `.venv`, or real `python3` on `PATH`), I want the
+   exact same interpreter chosen as before, so that this fix is invisible to me.
+5. As a maintainer, I want a one-line comment at each call site explaining why selection is
+   by execution and not `command -v`, so that nobody "simplifies" it back and reintroduces
+   the bug.
+6. As someone whose machine has only the broken stub, I want `update-skills` to fail with a
+   message that names the real problem (no *working* Python), not "no python3 or python on
+   PATH".
+
+## Implementation Decisions
+
+- Files touched: `.pre-commit-config.yaml`, `bin/update-skills`.
+- **`.pre-commit-config.yaml`** — replace the `sync-claude-skills` `entry`'s `if/elif` chain
+  with an inline `bash -c` loop over the same candidate list, each candidate guarded by
+  `"$py" -c "" >/dev/null 2>&1`, then `exec "$py" sync_claude_skills.py` on the first that
+  runs (`exec` so the script's exit status is what pre-commit sees). No new file — the entry
+  stays inline, matching current repo style. Trailing `echo ... >&2; exit 1` when the loop
+  exhausts. One `#` comment line above the hook explaining the execution-test rationale.
+- **`bin/update-skills`** — hoist the existing `runs_ok()` definition above the
+  "resolve Python interpreters" block and use it in the `sys_py` loop in place of
+  `command -v`. Reword the subsequent `die` from
+  `"no python3 or python on PATH; cannot create .venv."` to
+  `"no working python3 or python found; cannot create .venv."`. Add a one-line comment on the
+  `sys_py` loop mirroring the hook's.
+- Candidate precedence, the `pre-commit`/`post-commit` split, and every other behaviour are
+  unchanged. `[ -f ]` guards on the `.venv/...` paths become unnecessary (a non-existent
+  path fails the run-test) and are dropped from the hook entry; `bin/update-skills`'s
+  `pick_venv_py` keeps its `[ -x ]` guard (out of scope — it is not the buggy path).
+- No ADR: the change is trivially reversible and there is no real trade-off, only a
+  correctness fix. The inline comments carry the "why".
+- ADR `0005-worktree-bootstrap-reinstalls-rather-than-copies-dependencies.md` (rescued from a
+  deleted worktree during pre-work cleanup) is **not** part of this branch — it describes
+  behaviour `create-worktrees` does not implement and belongs with a dedicated change.
+
+## Testing Decisions
+
+- No test files. This is a shell/YAML config fix in a repo with no shell test harness;
+  adding one is out of scope.
+- Verification:
+  1. **Before/after reproduction on this machine** (the acceptance test): a trivial commit
+     on this branch — `post-commit` sync must run via `python`, exit 0, no stub error,
+     `~/.claude/skills` mtimes updated. Contrast with the pre-fix behaviour already observed
+     this session (exit 49, stub message, no sync).
+  2. **Manual candidate simulation**: run the extracted loop with `py` pointed at a fake
+     non-zero-exit stub then a real interpreter — confirm skip-then-pick; and with only a
+     failing candidate — confirm non-zero exit and the error line.
+  3. **`shellcheck`** via `pre-commit run --all-files` on `bin/update-skills`. The inline
+     YAML string is not shellcheck'd, so its quoting is eyeball-verified.
+  4. **Healthy-path check**: confirm an earlier candidate (`.venv/...` or a real `python3`)
+     still wins when present.
+
+## Out of Scope
+
+- `sync_claude_skills.py` itself — its unused `#!/usr/bin/env python3` shebang and its
+  `os.walk` descending into `.claude/worktrees/` (which can copy in-progress skill versions)
+  are separate pre-existing issues.
+- `install.sh` — no Python involvement.
+- Installing Python or disabling the Windows App Execution Alias — an environment change; the
+  point is that the repo works regardless.
+- Changing or extending the candidate list (e.g. `py -3`, versioned names).
+- ADR 0005 and any `create-worktrees` dependency-bootstrap behaviour.
+
+## Further Notes
+
+- `bin/update-skills`'s comment block already asserts its precedence "matches
+  `.pre-commit-config.yaml`'s sync-claude-skills hook" — fixing both together keeps that
+  promise true.
+- The rescued ADR 0005 draft remains an untracked file in the main checkout
+  (`.agent-docs/adr/0005-...md`) for a future dedicated change; it must not be lost.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,9 +51,7 @@ repos:
 
   - repo: local
     hooks:
-      # Pick the first candidate that actually RUNS, not the first on PATH: the Windows
-      # Store `python3` alias is on PATH but exits non-zero. Keep the candidate order in
-      # step with bin/update-skills. `exec` so the script's exit status is the hook's.
+      # Probe each candidate by running it, not `command -v` — the Windows Store `python3` alias is on PATH but exits non-zero. `exec` propagates the script's exit status. Same rationale in bin/update-skills.
       - id: sync-claude-skills
         name: Sync Claude skills to ~/.claude/skills
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,10 +51,13 @@ repos:
 
   - repo: local
     hooks:
+      # Pick the first candidate that actually RUNS, not the first on PATH: the Windows
+      # Store `python3` alias is on PATH but exits non-zero. Keep the candidate order in
+      # step with bin/update-skills. `exec` so the script's exit status is the hook's.
       - id: sync-claude-skills
         name: Sync Claude skills to ~/.claude/skills
         language: system
-        entry: bash -c "if [ -f .venv/Scripts/python ]; then .venv/Scripts/python sync_claude_skills.py; elif [ -f .venv/Scripts/python.exe ]; then .venv/Scripts/python.exe sync_claude_skills.py; elif [ -f .venv/bin/python ]; then .venv/bin/python sync_claude_skills.py; elif command -v python3 >/dev/null 2>&1; then python3 sync_claude_skills.py; else python sync_claude_skills.py; fi"
+        entry: bash -c 'for py in .venv/Scripts/python .venv/Scripts/python.exe .venv/bin/python python3 python; do "$py" -c "" >/dev/null 2>&1 && exec "$py" sync_claude_skills.py; done; echo "sync-claude-skills - no working python interpreter found" >&2; exit 1'
         stages: [post-commit]
         always_run: true
         pass_filenames: false

--- a/bin/update-skills
+++ b/bin/update-skills
@@ -62,12 +62,11 @@ fi
 # pip or the sync — every install and the sync itself run against the venv, so
 # `pip install` can't leak into system/user site-packages.
 
-# runs_ok <interpreter> — true if it executes at all. Selection is by execution,
-# not `command -v`: the Windows Store `python3` alias is on PATH but exits
-# non-zero, so `command -v` would pick an interpreter that can't run.
+# runs_ok <interpreter> — true if it executes at all
 runs_ok() { [ -n "$1" ] && "$1" -c '' >/dev/null 2>&1; }
 
 sys_py=""
+# Probe by running, not `command -v` — the Windows Store `python3` alias is on PATH but exits non-zero. Same rationale in .pre-commit-config.yaml.
 for candidate in python3 python; do
 	if runs_ok "$candidate"; then
 		sys_py="$candidate"

--- a/bin/update-skills
+++ b/bin/update-skills
@@ -61,9 +61,15 @@ fi
 # two system candidates are only ever used to *create* the venv, never to run
 # pip or the sync — every install and the sync itself run against the venv, so
 # `pip install` can't leak into system/user site-packages.
+
+# runs_ok <interpreter> — true if it executes at all. Selection is by execution,
+# not `command -v`: the Windows Store `python3` alias is on PATH but exits
+# non-zero, so `command -v` would pick an interpreter that can't run.
+runs_ok() { [ -n "$1" ] && "$1" -c '' >/dev/null 2>&1; }
+
 sys_py=""
 for candidate in python3 python; do
-	if command -v "$candidate" >/dev/null 2>&1; then
+	if runs_ok "$candidate"; then
 		sys_py="$candidate"
 		break
 	fi
@@ -80,15 +86,12 @@ pick_venv_py() {
 }
 
 # --- first-run bootstrap: .venv + pre-commit hooks ----------------------
-# runs_ok <interpreter> — true if it executes at all
-runs_ok() { [ -n "$1" ] && "$1" -c '' >/dev/null 2>&1; }
-
 venv_py="$(pick_venv_py)"
 if [ -n "$venv_py" ] && ! runs_ok "$venv_py"; then
 	die ".venv exists but its interpreter ($venv_py) won't run — delete .venv and re-run."
 fi
 if [ -z "$venv_py" ]; then
-	[ -n "$sys_py" ] || die "no python3 or python on PATH; cannot create .venv."
+	[ -n "$sys_py" ] || die "no working python3 or python found; cannot create .venv."
 	say "Creating .venv"
 	"$sys_py" -m venv .venv
 	venv_py="$(pick_venv_py)"


### PR DESCRIPTION
## Summary

The `sync-claude-skills` `post-commit` hook and `bin/update-skills`' `sys_py` loop both chose a Python interpreter by testing *existence* (`command -v` / `[ -f ]`). The Windows Store `python3` App Execution Alias is a real file on `PATH` that just prints "Python was not found…" and exits non-zero — so `command -v python3` succeeds, the hook runs a broken interpreter (exit 49), and the `post-commit` sync silently stops happening, leaving `~/.claude/skills` stale. (This bit the uv-support change earlier — it didn't propagate to the installed skill.)

## Changes

- **`.pre-commit-config.yaml`** — the `sync-claude-skills` `entry` is now an inline `bash -c` loop over the same candidate list (`.venv/Scripts/python[.exe]` → `.venv/bin/python` → `python3` → `python`), each candidate guarded by `"$py" -c "" >/dev/null 2>&1` (it must *run*), `exec`-ing the first that works so its exit status is the hook's. If none run, it prints a one-line error to stderr and exits non-zero — loud, not a silent skip. One rationale comment.
- **`bin/update-skills`** — the existing `runs_ok()` helper (`"$1" -c '' >/dev/null 2>&1`) is hoisted above the interpreter-resolution block and used in the `sys_py` loop in place of `command -v`. The "cannot create `.venv`" `die` message now says "no *working* python3 or python found". One rationale comment on the loop.
- Candidate precedence, the `pre-commit`/`post-commit` split, and every other behaviour are unchanged.
- `.agent-docs/specs/` + `.agent-docs/issues/` entries for the slice (#75).

## Test plan

- **Acceptance test (this machine):** `git commit` on the branch → `post-commit` hook reports `Sync Claude skills to ~/.claude/skills … Passed` (pre-fix: `Failed / exit code 49` on every commit). The loop skips the missing `.venv/*` paths and the exit-49 `python3` stub and lands on `python` 3.14.7; running the exact entry manually gives `rc=0`.
- **Candidate simulation:** loop against a fake exit-49 stub + a real interpreter → skips stub, picks real; against only-failing candidates → non-zero exit + the error line.
- `pre-commit run --all-files` passes; `shellcheck` clean on `bin/update-skills` (both passes).
- Two-axis `code-review` (Standards + Spec) run to two consecutive clean passes.

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)