### PR TITLE
Rewrite create-a-skill around the writing levers

### DIFF
--- a/.agent-docs/context.md
+++ b/.agent-docs/context.md
@@ -22,6 +22,26 @@ _Avoid_: detail file, command reference, documentation file
 A file used by orchestrating skills (e.g. `implement`) to define a multi-step workflow executed inline in the current conversation rather than delegated to a sub-agent.
 _Avoid_: process file, workflow definition
 
+### Skill Authoring
+
+Vocabulary for writing skills, applied by `create-a-skill` (adapted from Matt Pocock's `writing-for-agents`).
+
+**Context pointer**:
+A reference held in the agent's context that names out-of-context material and encodes the condition for reaching it — a skill's `description`, or a line in `CLAUDE.md` naming a doc. The pointer's wording, not its target, decides when and how reliably the material is reached.
+_Avoid_: reference, link, trigger
+
+**Information hierarchy**:
+The ladder that ranks a skill's material by how immediately the agent needs it: in-file step, then in-file reference, then disclosed reference (pushed into a pointer-reached file). Where each piece sits is the core structuring decision.
+_Avoid_: structure, layout, organisation
+
+**Progressive disclosure**:
+Moving material down the information hierarchy — out of `SKILL.md` and behind a context pointer — so the top stays legible. Driven by branching: inline what every branch needs, disclose what only some branches reach.
+_Avoid_: extraction, splitting, factoring out
+
+**Leading word**:
+A compact concept already in the model's pretraining (`tracer bullet`, `red`, `fog of war`) repeated as a token, never a sentence, so it accumulates a distributed definition and anchors a region of behaviour cheaply.
+_Avoid_: keyword, term, jargon
+
 ### Skill Distribution
 
 **`sync_claude_skills.py`**:

--- a/.agent-docs/issues/chore/improve-create-a-skill.md
+++ b/.agent-docs/issues/chore/improve-create-a-skill.md
@@ -51,16 +51,18 @@ No change to any other skill, or to `create-a-skill`'s `name` / invocation model
 
 ### Acceptance criteria
 
-- [ ] `create-a-skill/SKILL.md` `## Process` produces a skill against the levers (gather with
-      model/user-invoked -> place on hierarchy -> draft with pointer/criterion/leading-word
-      rules -> review -> verify against checklist); structure diagram + `SKILL.md` template
-      retained; template shows a sample completion criterion.
-- [ ] `create-a-skill/SKILL.md` is <= ~150 lines (target ~90) and has exactly one pointer
-      (to `REFERENCE.md`).
+- [ ] `create-a-skill/SKILL.md` `## Process` has five steps (gather incl. model/user-invoked
+      -> place on the information hierarchy -> draft applying every lever -> review against
+      the step-1 use cases -> verify against the Review Checklist); each step ends on a
+      completion criterion and **points at `REFERENCE.md` for the rules rather than restating
+      them**; structure diagram + `SKILL.md` template retained; template shows a sample
+      completion criterion.
+- [ ] `create-a-skill/SKILL.md` is <= ~150 lines (target ~55); one markdown pointer target
+      (`REFERENCE.md`), references one level deep.
 - [ ] `create-a-skill/REFERENCE.md` has `## Writing levers` covering context pointer, the
       two loads, information hierarchy, progressive disclosure, co-location, completion
-      criteria, when to split, leading words, steer positive, pruning — each a terse
-      imperative rule ending on a check.
+      criteria, when to split, leading words, steer positive, pruning — each a terse rule of
+      one to three sentences ending on an explicit `*Check:*` line.
 - [ ] `create-a-skill/REFERENCE.md` has `## Model- vs user-invoked` (`disable-model-invocation`,
       router skills) and `## Common failure modes` (Sprawl / Negation steering / Duplication /
       Scattering / No-op / Premature completion, each with its fix).
@@ -70,16 +72,18 @@ No change to any other skill, or to `create-a-skill`'s `name` / invocation model
 - [ ] The 100-vs-500 contradiction is gone: `SKILL.md`, `REFERENCE.md` "When to split
       files", and the checklist all say the same thing — ~150 = sprawl smell, branch test
       drives it.
-- [ ] `## Review checklist` is revised to ~10 grouped pass/fail items covering Pointer,
-      Hierarchy & disclosure, Completion criteria, Leading words & positivity, and General
-      (`name:` matches directory, no time-sensitive info, consistent terminology, concrete
-      examples).
+- [ ] `## Review Checklist` is revised to grouped pass/fail items (Pointer, Hierarchy &
+      disclosure, Completion criteria, Leading words & positivity, General) that **reference
+      the rules rather than re-spell enumerations** — the `~150` number and the "every X /
+      not a list" phrasing each live once in their own section.
 - [ ] Each lever's rule appears once in `## Writing levers`; `SKILL.md` and the checklist
-      reference it, not restate it.
+      reference it, not restate it — SKILL.md steps name the `REFERENCE.md` section, the
+      checklist points at *Description requirements* / *When to split files*.
 - [ ] `create-a-skill` passes its own revised checklist: description front-loads the trigger
-      word with three distinct branches; one pointer, one level deep; positive phrasing (a
-      "don't ..." only as a paired guardrail); reaches for leading words where a triad
-      repeats.
+      word with three distinct branches and no body-restating clause; one pointer target,
+      one level deep; every step ends on a checkable + exhaustive criterion; positive
+      phrasing (a "don't ..." only as a paired guardrail); reaches for leading words where a
+      triad repeats.
 - [ ] Content is credited in one line as adapted from `writing-for-agents`.
 - [ ] `.agent-docs/context.md` has the "Skill Authoring" glossary cluster.
 - [ ] `pre-commit run --all-files` passes.

--- a/.agent-docs/issues/chore/improve-create-a-skill.md
+++ b/.agent-docs/issues/chore/improve-create-a-skill.md
@@ -13,7 +13,7 @@ skill against a named set of **writing levers** (adapted from Matt Pocock's
 `writing-for-agents`, credited in one line, absorbed self-contained — no runtime dependency
 on the plugin). Fix the 100-vs-500 `SKILL.md` split contradiction with a single rule.
 
-- **`create-a-skill/SKILL.md`** (~90 lines; hard ceiling ~150):
+- **`create-a-skill/SKILL.md`** (~55 lines; hard ceiling ~150):
   - Frontmatter `description` rewritten as a context pointer: front-loaded trigger word;
     three genuinely distinct branches — create a new skill / revise an existing one / review
     a skill against the levers — with "create, write, or build" (synonym-branches)

--- a/.agent-docs/issues/chore/improve-create-a-skill.md
+++ b/.agent-docs/issues/chore/improve-create-a-skill.md
@@ -1,0 +1,88 @@
+# Issues: chore/improve-create-a-skill
+
+## Rewrite create-a-skill around the writing levers (#79)
+
+**Blocked by**: None
+
+**User stories**: 1, 2, 3, 4, 5, 6, 7, 8
+
+### What to build
+
+Rewrite `create-a-skill/SKILL.md` and `create-a-skill/REFERENCE.md` so the skill produces a
+skill against a named set of **writing levers** (adapted from Matt Pocock's
+`writing-for-agents`, credited in one line, absorbed self-contained — no runtime dependency
+on the plugin). Fix the 100-vs-500 `SKILL.md` split contradiction with a single rule.
+
+- **`create-a-skill/SKILL.md`** (~90 lines; hard ceiling ~150):
+  - Frontmatter `description` rewritten as a context pointer: front-loaded trigger word;
+    three genuinely distinct branches — create a new skill / revise an existing one / review
+    a skill against the levers — with "create, write, or build" (synonym-branches)
+    collapsed.
+  - Short intro + one pointer to `REFERENCE.md` for the levers and the checklist.
+  - `## Process` rewritten: (1) gather — task/domain, use cases, scripts-or-not, reference
+    materials, **model- vs user-invoked**; (2) place each piece of content on the
+    information hierarchy, disclosing what only some branches reach; (3) draft — description
+    as a context pointer, each step on a checkable + exhaustive completion criterion, reach
+    for leading words, steer positive; (4) review with the user; (5) verify against the
+    Review Checklist in `REFERENCE.md`.
+  - Keep the skill-structure diagram and the `SKILL.md` template; the template gains a
+    one-line sample completion criterion.
+- **`create-a-skill/REFERENCE.md`** (target ~130 lines; must not itself sprawl):
+  - `## Description requirements` — kept, folded with the pointer-writing rules.
+  - `## Writing levers` — terse imperative rules, each ending on a check: context pointer,
+    the two loads, information hierarchy, progressive disclosure, co-location, completion
+    criteria, when to split, leading words, steer positive, pruning.
+  - `## Model- vs user-invoked` — `description` vs `disable-model-invocation: true`; router
+    skills.
+  - `## When to add scripts` — kept.
+  - `## When to split files` — reconciled: past ~150 lines `SKILL.md` is a sprawl smell;
+    the branch test is the real driver, not the line count.
+  - `## Common failure modes` — named one-line list: Sprawl / Negation steering /
+    Duplication / Scattering / No-op / Premature completion, each with its fix.
+  - `## Review checklist` — revised, ~10 grouped pass/fail items (Pointer / Hierarchy /
+    Completion criteria / Leading words & positivity / General).
+- **`.agent-docs/context.md`** — "Skill Authoring" cluster with Context pointer, Information
+  hierarchy, Progressive disclosure, Leading word (done inline during the grill; this issue
+  carries it through).
+- Each lever's rule is stated once (in `## Writing levers`) and referenced — not restated —
+  by `SKILL.md` and the checklist.
+
+No change to any other skill, or to `create-a-skill`'s `name` / invocation model.
+
+### Acceptance criteria
+
+- [ ] `create-a-skill/SKILL.md` `## Process` produces a skill against the levers (gather with
+      model/user-invoked -> place on hierarchy -> draft with pointer/criterion/leading-word
+      rules -> review -> verify against checklist); structure diagram + `SKILL.md` template
+      retained; template shows a sample completion criterion.
+- [ ] `create-a-skill/SKILL.md` is <= ~150 lines (target ~90) and has exactly one pointer
+      (to `REFERENCE.md`).
+- [ ] `create-a-skill/REFERENCE.md` has `## Writing levers` covering context pointer, the
+      two loads, information hierarchy, progressive disclosure, co-location, completion
+      criteria, when to split, leading words, steer positive, pruning — each a terse
+      imperative rule ending on a check.
+- [ ] `create-a-skill/REFERENCE.md` has `## Model- vs user-invoked` (`disable-model-invocation`,
+      router skills) and `## Common failure modes` (Sprawl / Negation steering / Duplication /
+      Scattering / No-op / Premature completion, each with its fix).
+- [ ] `## Description requirements` is kept and folded with the pointer-writing rules
+      (front-load the trigger word; one trigger per branch; cut identity the body carries;
+      third person; <=1024 chars; first sentence what it does, second "Use when ...").
+- [ ] The 100-vs-500 contradiction is gone: `SKILL.md`, `REFERENCE.md` "When to split
+      files", and the checklist all say the same thing — ~150 = sprawl smell, branch test
+      drives it.
+- [ ] `## Review checklist` is revised to ~10 grouped pass/fail items covering Pointer,
+      Hierarchy & disclosure, Completion criteria, Leading words & positivity, and General
+      (`name:` matches directory, no time-sensitive info, consistent terminology, concrete
+      examples).
+- [ ] Each lever's rule appears once in `## Writing levers`; `SKILL.md` and the checklist
+      reference it, not restate it.
+- [ ] `create-a-skill` passes its own revised checklist: description front-loads the trigger
+      word with three distinct branches; one pointer, one level deep; positive phrasing (a
+      "don't ..." only as a paired guardrail); reaches for leading words where a triad
+      repeats.
+- [ ] Content is credited in one line as adapted from `writing-for-agents`.
+- [ ] `.agent-docs/context.md` has the "Skill Authoring" glossary cluster.
+- [ ] `pre-commit run --all-files` passes.
+- [ ] No other skill's files are changed.
+
+---

--- a/.agent-docs/issues/chore/improve-create-a-skill.md
+++ b/.agent-docs/issues/chore/improve-create-a-skill.md
@@ -1,5 +1,7 @@
 # Issues: chore/improve-create-a-skill
 
+> Work complete — PR ready to merge.
+
 ## Rewrite create-a-skill around the writing levers (#79)
 
 **Blocked by**: None
@@ -51,45 +53,45 @@ No change to any other skill, or to `create-a-skill`'s `name` / invocation model
 
 ### Acceptance criteria
 
-- [ ] `create-a-skill/SKILL.md` `## Process` has five steps (gather incl. model/user-invoked
+- [x] `create-a-skill/SKILL.md` `## Process` has five steps (gather incl. model/user-invoked
       -> place on the information hierarchy -> draft applying every lever -> review against
       the step-1 use cases -> verify against the Review Checklist); each step ends on a
       completion criterion and **names the `REFERENCE.md` section rather than restating any
       rule** — no inline tier lists, rule enumerations, or trigger lists; structure diagram +
       `SKILL.md` template retained (diagram comments are bare role labels; `scripts/` points
       at "When to add scripts"); template shows a sample completion criterion.
-- [ ] `create-a-skill/SKILL.md` is <= ~150 lines (target ~55); one markdown pointer target
+- [x] `create-a-skill/SKILL.md` is <= ~150 lines (target ~55); one markdown pointer target
       (`REFERENCE.md`), references one level deep.
-- [ ] `create-a-skill/REFERENCE.md` has `## Writing levers` covering context pointer, the
+- [x] `create-a-skill/REFERENCE.md` has `## Writing levers` covering context pointer, the
       two loads, information hierarchy, progressive disclosure, co-location, completion
       criteria, when to split, leading words, steer positive, pruning — each a terse rule of
       one to three sentences ending on an explicit `*Check:*` line.
-- [ ] `create-a-skill/REFERENCE.md` has `## Model- vs user-invoked` (`disable-model-invocation`,
+- [x] `create-a-skill/REFERENCE.md` has `## Model- vs user-invoked` (`disable-model-invocation`,
       router skills) and `## Common failure modes` (Sprawl / Negation steering / Duplication /
       Scattering / No-op / Premature completion, each with its fix).
-- [ ] `## Description requirements` is kept and folded with the pointer-writing rules
+- [x] `## Description requirements` is kept and folded with the pointer-writing rules
       (front-load the trigger word; one trigger per branch; cut identity the body carries;
       third person; <=1024 chars; first sentence what it does, second "Use when ...").
-- [ ] The 100-vs-500 contradiction is gone: `SKILL.md`, `REFERENCE.md` "When to split
+- [x] The 100-vs-500 contradiction is gone: `SKILL.md`, `REFERENCE.md` "When to split
       files", and the checklist all say the same thing — ~150 = sprawl smell, branch test
       drives it.
-- [ ] `## Review Checklist` is revised to grouped pass/fail items (Pointer, Hierarchy &
+- [x] `## Review Checklist` is revised to grouped pass/fail items (Pointer, Hierarchy &
       disclosure, Completion criteria, Leading words & positivity, General) that **reference
       the rules rather than re-spell enumerations** — the `~150` number and the "every X /
       not a list" phrasing each live once in their own section. The Hierarchy item admits
       named-pointer disclosure (a step's rules/reference may sit behind a pointer the step
       names) so create-a-skill's own disclosure of the levers is not a self-fail.
-- [ ] Each lever's rule appears once in `## Writing levers`; `SKILL.md` and the checklist
+- [x] Each lever's rule appears once in `## Writing levers`; `SKILL.md` and the checklist
       reference it, not restate it — SKILL.md steps name the `REFERENCE.md` section, the
       checklist points at *Description requirements* / *When to split files*.
-- [ ] `create-a-skill` passes its own revised checklist: description front-loads the trigger
+- [x] `create-a-skill` passes its own revised checklist: description front-loads the trigger
       word with three distinct branches and no body-restating clause; one pointer target,
       one level deep; every step ends on a checkable + exhaustive criterion; positive
       phrasing (a "don't ..." only as a paired guardrail); reaches for leading words where a
       triad repeats.
-- [ ] Content is credited in one line as adapted from `writing-for-agents`.
-- [ ] `.agent-docs/context.md` has the "Skill Authoring" glossary cluster.
-- [ ] `pre-commit run --all-files` passes.
-- [ ] No other skill's files are changed.
+- [x] Content is credited in one line as adapted from `writing-for-agents`.
+- [x] `.agent-docs/context.md` has the "Skill Authoring" glossary cluster.
+- [x] `pre-commit run --all-files` passes.
+- [x] No other skill's files are changed.
 
 ---

--- a/.agent-docs/issues/chore/improve-create-a-skill.md
+++ b/.agent-docs/issues/chore/improve-create-a-skill.md
@@ -54,9 +54,10 @@ No change to any other skill, or to `create-a-skill`'s `name` / invocation model
 - [ ] `create-a-skill/SKILL.md` `## Process` has five steps (gather incl. model/user-invoked
       -> place on the information hierarchy -> draft applying every lever -> review against
       the step-1 use cases -> verify against the Review Checklist); each step ends on a
-      completion criterion and **points at `REFERENCE.md` for the rules rather than restating
-      them**; structure diagram + `SKILL.md` template retained; template shows a sample
-      completion criterion.
+      completion criterion and **names the `REFERENCE.md` section rather than restating any
+      rule** — no inline tier lists, rule enumerations, or trigger lists; structure diagram +
+      `SKILL.md` template retained (diagram comments are bare role labels; `scripts/` points
+      at "When to add scripts"); template shows a sample completion criterion.
 - [ ] `create-a-skill/SKILL.md` is <= ~150 lines (target ~55); one markdown pointer target
       (`REFERENCE.md`), references one level deep.
 - [ ] `create-a-skill/REFERENCE.md` has `## Writing levers` covering context pointer, the
@@ -75,7 +76,9 @@ No change to any other skill, or to `create-a-skill`'s `name` / invocation model
 - [ ] `## Review Checklist` is revised to grouped pass/fail items (Pointer, Hierarchy &
       disclosure, Completion criteria, Leading words & positivity, General) that **reference
       the rules rather than re-spell enumerations** — the `~150` number and the "every X /
-      not a list" phrasing each live once in their own section.
+      not a list" phrasing each live once in their own section. The Hierarchy item admits
+      named-pointer disclosure (a step's rules/reference may sit behind a pointer the step
+      names) so create-a-skill's own disclosure of the levers is not a self-fail.
 - [ ] Each lever's rule appears once in `## Writing levers`; `SKILL.md` and the checklist
       reference it, not restate it — SKILL.md steps name the `REFERENCE.md` section, the
       checklist points at *Description requirements* / *When to split files*.

--- a/.agent-docs/review.md
+++ b/.agent-docs/review.md
@@ -39,3 +39,19 @@ from — for example:
   wording reads as a contradiction. Also verify any claim that characterises a referenced
   document ("X only documents the upgrade flow", "Y has none of these") against that
   document. (PR #78)
+- **Doc fails its own standard**: when a file defines a checklist or rule set, flag any part
+  of that same file that breaks one of its own rules — a `description` that isn't third
+  person, a section longer than the length limit the file itself sets. (PR #80)
+- **Vague pointer where a precise anchor exists**: flag a cross-reference that names only the
+  target file when it could name the specific section or heading the reader needs — most of
+  all when the spec asks for the precise form. (PR #80)
+- **Inconsistent element across a parallel series**: flag a sequence of parallel items
+  (steps, sections, list entries) where one omits a structural element its siblings all
+  carry — a completion criterion, a "Done when", a heading. (PR #80)
+- **Rule looser than the check that enforces it**: flag a blanket rule with an unlisted
+  special case that breaks it, or a rule whose wording is vaguer than the checklist item
+  that tests it (prose says "first sentence … second sentence"; checklist says "exactly
+  two"); both places must state the same constraint. (PR #80)
+- **Coined word spellcheck will flag**: flag an invented compound or coinage in prose that
+  codespell or similar tooling is likely to trip on; prefer plain phrasing unless the term
+  is a deliberately pinned leading word. (PR #80)

--- a/.agent-docs/specs/chore/improve-create-a-skill.md
+++ b/.agent-docs/specs/chore/improve-create-a-skill.md
@@ -70,7 +70,9 @@ branch test, not the line count, is the real driver.
     them** — no inline tier lists, rule enumerations, or trigger lists: (1) gather
     requirements — task/domain and use cases, scripts-or-not, reference material, model- vs
     user-invoked — done once every question is answered; (2) place each piece of content on
-    the information hierarchy by the branch test — done when every piece has a place; (3)
+    the information hierarchy, naming *Progressive disclosure* for the branch test (which is
+    defined there, as a token, so the pointer has an anchor) — done when every piece has a
+    place; (3)
     draft the files, applying every writing lever from `REFERENCE.md` — done when every lever
     holds; (4) review with the user against the step-1 use cases — done when each is covered
     and the user has nothing to add; (5) verify against the Review Checklist.

--- a/.agent-docs/specs/chore/improve-create-a-skill.md
+++ b/.agent-docs/specs/chore/improve-create-a-skill.md
@@ -58,28 +58,31 @@ branch test, not the line count, is the real driver.
 - **Self-contained absorption.** The levers are folded into `create-a-skill/REFERENCE.md` in
   this repo's voice, credited in one line as adapted from `writing-for-agents`. No pointer to
   the plugin as a required read; `create-a-skill` must stand alone if the plugin is absent.
-- **`create-a-skill/SKILL.md`** (~90 lines, hard ceiling ~150):
-  - Frontmatter `description` rewritten to obey the new pointer rules: front-loaded trigger
-    word, three genuinely distinct branches — create a new skill / revise an existing one /
-    review a skill against the levers — with the synonym-branch "create, write, or build"
-    collapsed.
-  - Short intro + one pointer to `REFERENCE.md` for the levers and the checklist.
-  - `## Process` rewritten to numbered steps: (1) gather requirements — task/domain, use
-    cases, scripts-or-not, reference materials, **and model- vs user-invoked**; (2) place
-    each piece of content on the information hierarchy, disclosing what only some branches
-    reach; (3) draft `SKILL.md` (+ `REFERENCE.md`/`EXAMPLES.md` when branch-only content or
-    sprawl warrants) writing the description as a context pointer, giving each step a
-    checkable + exhaustive completion criterion, reaching for leading words, steering
-    positive; (4) review with the user; (5) verify against the Review Checklist in
-    `REFERENCE.md`.
-  - Keep the skill-structure diagram and the `SKILL.md` template unchanged in substance; the
-    template gains a one-line sample completion criterion in its `## Workflows` slot.
+- **`create-a-skill/SKILL.md`** (~55 lines, hard ceiling ~150):
+  - Frontmatter `description` — front-loaded trigger word; three genuinely distinct branches
+    (create a new skill / rework an existing one / review a skill against the levers); the
+    synonym-branch "create, write, or build" collapsed; no clause restating what the body
+    covers.
+  - Short intro + one markdown pointer to `REFERENCE.md` for the levers, the description
+    rules, the model/user-invocation choice, and the Review Checklist.
+  - `## Process` rewritten to five numbered steps, each ending on a completion criterion, and
+    **each pointing at `REFERENCE.md` for the rules rather than restating them**: (1) gather
+    requirements — task/domain and use cases, scripts-or-not, reference material, model- vs
+    user-invoked — done once every question is answered; (2) place each piece of content on
+    the information hierarchy by the branch test — done when every piece has a place; (3)
+    draft the files, applying every writing lever from `REFERENCE.md` — done when every lever
+    holds; (4) review with the user against the step-1 use cases — done when each is covered
+    and the user has nothing to add; (5) verify against the Review Checklist.
+  - Keep the skill-structure diagram and the `SKILL.md` template; the template's `## Workflows`
+    slot shows a one-line sample completion criterion. The diagram section does **not** carry
+    the sprawl rule (it lives once in `REFERENCE.md`'s "When to split files").
 - **`create-a-skill/REFERENCE.md`** (target ~130 lines; must not itself sprawl):
   - `## Description requirements` — kept, folded with the pointer-writing rules (front-load
     the trigger word; one trigger per branch, no synonym-branches; cut identity the body
     carries; third person; <=1024 chars; first sentence = what it does, second = "Use
     when …").
-  - `## Writing levers` — each a terse imperative rule ending on a check:
+  - `## Writing levers` — each a terse rule of one to three sentences ending on an explicit
+    `*Check:*` line the draft has to pass:
     **context pointer** (wording not target decides reliability; the pointer-writing rules);
     **the two loads** (context load vs cognitive load; disclosure trades one for the other);
     **information hierarchy** (in-file step > in-file reference > disclosed reference; inline
@@ -114,15 +117,17 @@ branch test, not the line count, is the real driver.
     fragmented across headings -> co-locate); **No-op** (a line the model already obeys ->
     delete the sentence, or use a stronger leading word); **Premature completion** (a step
     stops before it is done -> sharpen the criterion, then split the sequence).
-  - `## Review checklist` — revised, ~10 grouped pass/fail items:
-    - Pointer: description front-loads the trigger word; one trigger per branch; no identity
-      the body repeats; third person; <=1024 chars; second sentence is "Use when …".
-    - Hierarchy: branch-only sections are disclosed behind a pointer; every-branch material
-      is in-file; `SKILL.md` is not sprawling (~150); references are one level deep.
+  - `## Review Checklist` — revised, grouped pass/fail items that **reference the rules
+    rather than re-spell enumerations** (the `~150` number and the "every X / not a list"
+    phrasing each live once in their own section):
+    - Pointer: the description passes every rule in *Description requirements*.
+    - Hierarchy & disclosure: material every run needs is in `SKILL.md`; branch-only sections
+      are disclosed behind a pointer; references one level deep; `SKILL.md` is not sprawling
+      (see *When to split files*).
     - Completion criteria: every step ends on a checkable and exhaustive criterion.
-    - Leading words / positivity: reaches for >=1 leading word where a triad or phrase
-      repeats; steers positive (a "don't …" appears only as a guardrail paired with the
-      positive target).
+    - Leading words & positivity: reaches for a leading word where a triad or phrase repeats;
+      steers positive (a "don't …" appears only as a guardrail paired with the positive
+      target).
     - General: `name:` matches the directory; no time-sensitive info; consistent
       terminology; concrete examples included.
 - **`create-a-skill` passes its own revised checklist** — this is an explicit acceptance

--- a/.agent-docs/specs/chore/improve-create-a-skill.md
+++ b/.agent-docs/specs/chore/improve-create-a-skill.md
@@ -66,7 +66,8 @@ branch test, not the line count, is the real driver.
   - Short intro + one markdown pointer to `REFERENCE.md` for the levers, the description
     rules, the model/user-invocation choice, and the Review Checklist.
   - `## Process` rewritten to five numbered steps, each ending on a completion criterion, and
-    **each pointing at `REFERENCE.md` for the rules rather than restating them**: (1) gather
+    **each naming the `REFERENCE.md` section for the rules rather than restating any of
+    them** — no inline tier lists, rule enumerations, or trigger lists: (1) gather
     requirements — task/domain and use cases, scripts-or-not, reference material, model- vs
     user-invoked — done once every question is answered; (2) place each piece of content on
     the information hierarchy by the branch test — done when every piece has a place; (3)
@@ -74,8 +75,10 @@ branch test, not the line count, is the real driver.
     holds; (4) review with the user against the step-1 use cases — done when each is covered
     and the user has nothing to add; (5) verify against the Review Checklist.
   - Keep the skill-structure diagram and the `SKILL.md` template; the template's `## Workflows`
-    slot shows a one-line sample completion criterion. The diagram section does **not** carry
-    the sprawl rule (it lives once in `REFERENCE.md`'s "When to split files").
+    slot shows a one-line sample completion criterion. The diagram's per-line comments are
+    bare role labels — the `scripts/` line points at "When to add scripts" rather than
+    restating a subset of its triggers — and the diagram section does **not** carry the
+    sprawl rule (it lives once in `REFERENCE.md`'s "When to split files").
 - **`create-a-skill/REFERENCE.md`** (target ~130 lines; must not itself sprawl):
   - `## Description requirements` — kept, folded with the pointer-writing rules (front-load
     the trigger word; one trigger per branch, no synonym-branches; cut identity the body
@@ -121,9 +124,10 @@ branch test, not the line count, is the real driver.
     rather than re-spell enumerations** (the `~150` number and the "every X / not a list"
     phrasing each live once in their own section):
     - Pointer: the description passes every rule in *Description requirements*.
-    - Hierarchy & disclosure: material every run needs is in `SKILL.md`; branch-only sections
-      are disclosed behind a pointer; references one level deep; `SKILL.md` is not sprawling
-      (see *When to split files*).
+    - Hierarchy & disclosure: each step's actions are in `SKILL.md`; the rules and reference
+      a step consults may sit behind a pointer the step names; branch-only material is
+      disclosed, not inline; references one level deep; `SKILL.md` is not sprawling (see
+      *When to split files*).
     - Completion criteria: every step ends on a checkable and exhaustive criterion.
     - Leading words & positivity: reaches for a leading word where a triad or phrase repeats;
       steers positive (a "don't …" appears only as a guardrail paired with the positive

--- a/.agent-docs/specs/chore/improve-create-a-skill.md
+++ b/.agent-docs/specs/chore/improve-create-a-skill.md
@@ -1,0 +1,169 @@
+# Improve and fix create-a-skill
+
+## Problem Statement
+
+`create-a-skill` is the skill that tells an agent how to write a new skill, yet it is thin
+and partly self-contradictory:
+
+- **It contradicts itself on when to split `SKILL.md`.** `SKILL.md` step 2 says add
+  reference files "if content exceeds 500 lines"; `REFERENCE.md`'s "When to Split Files" and
+  the Review Checklist both say 100. An author following it can't tell which number to obey.
+- **It teaches structure, not the levers that make a skill reliable.** It has a 4-step
+  process, a structure diagram, a `SKILL.md` template, and a 6-item checklist — but nothing
+  about how a `description` actually triggers, where content should sit relative to how
+  urgently the agent needs it, what makes a step's stopping condition sound, or how word
+  choice steers behaviour. Skills written against it come out structurally plausible and
+  behaviourally vague.
+- **The concepts that would fix this already exist**, well-developed, in Matt Pocock's
+  `writing-for-agents` skill (installed as the `mattpocock-skills:writing-for-agents`
+  plugin) — but nothing in this repo points an author at them.
+
+## Solution
+
+Rewrite `create-a-skill/SKILL.md` and `create-a-skill/REFERENCE.md` so the skill produces a
+skill against a named set of **writing levers**, adapted from `writing-for-agents` into this
+repo's voice and kept as terse, testable rules rather than essay prose. `create-a-skill`
+becomes self-contained (no runtime dependency on the plugin) and passes its own revised
+checklist. The 100/500 contradiction is replaced by a single rule: ~150 lines in `SKILL.md`
+is a *sprawl smell* prompting a look for reference to disclose or a sequence to split — the
+branch test, not the line count, is the real driver.
+
+## User Stories
+
+1. As an agent asked to create a skill, I want `create-a-skill` to tell me how to write the
+   `description` as a context pointer — front-load the trigger word, one trigger per branch,
+   cut identity the body already carries — so the skill actually fires when it should.
+2. As an agent drafting a skill's body, I want a rule for where each piece of content sits
+   (in-file step / in-file reference / disclosed reference) and a branch test for what to
+   push behind a pointer, so `SKILL.md` stays legible without hiding material the agent
+   needs.
+3. As an agent writing a skill's steps, I want each step to end on a stopping condition that
+   is both checkable (done vs not-done) and exhaustive ("every X accounted for"), so the
+   skill doesn't stop a step early.
+4. As a skill author, I want a single answer to "how long can `SKILL.md` be?" instead of
+   three different numbers.
+5. As a skill author, I want to reach for pretrained **leading words** where a triad or
+   phrase repeats, and to state behaviour **positively** rather than by prohibition.
+6. As a skill author, I want to choose **model- vs user-invocation** deliberately, and to
+   know when a **router skill** is the answer to too many user-invoked skills.
+7. As a reviewer, I want a revised checklist that tests the levers (not just "has a
+   description"), so a non-compliant skill fails the gate.
+8. As a maintainer, I want `create-a-skill` to pass its own revised checklist, so the skill
+   that defines the standard also meets it.
+
+## Implementation Decisions
+
+- Files touched: `create-a-skill/SKILL.md`, `create-a-skill/REFERENCE.md`,
+  `.agent-docs/context.md` (4 glossary terms — done inline during the grill).
+- **Self-contained absorption.** The levers are folded into `create-a-skill/REFERENCE.md` in
+  this repo's voice, credited in one line as adapted from `writing-for-agents`. No pointer to
+  the plugin as a required read; `create-a-skill` must stand alone if the plugin is absent.
+- **`create-a-skill/SKILL.md`** (~90 lines, hard ceiling ~150):
+  - Frontmatter `description` rewritten to obey the new pointer rules: front-loaded trigger
+    word, three genuinely distinct branches — create a new skill / revise an existing one /
+    review a skill against the levers — with the synonym-branch "create, write, or build"
+    collapsed.
+  - Short intro + one pointer to `REFERENCE.md` for the levers and the checklist.
+  - `## Process` rewritten to numbered steps: (1) gather requirements — task/domain, use
+    cases, scripts-or-not, reference materials, **and model- vs user-invoked**; (2) place
+    each piece of content on the information hierarchy, disclosing what only some branches
+    reach; (3) draft `SKILL.md` (+ `REFERENCE.md`/`EXAMPLES.md` when branch-only content or
+    sprawl warrants) writing the description as a context pointer, giving each step a
+    checkable + exhaustive completion criterion, reaching for leading words, steering
+    positive; (4) review with the user; (5) verify against the Review Checklist in
+    `REFERENCE.md`.
+  - Keep the skill-structure diagram and the `SKILL.md` template unchanged in substance; the
+    template gains a one-line sample completion criterion in its `## Workflows` slot.
+- **`create-a-skill/REFERENCE.md`** (target ~130 lines; must not itself sprawl):
+  - `## Description requirements` — kept, folded with the pointer-writing rules (front-load
+    the trigger word; one trigger per branch, no synonym-branches; cut identity the body
+    carries; third person; <=1024 chars; first sentence = what it does, second = "Use
+    when …").
+  - `## Writing levers` — each a terse imperative rule ending on a check:
+    **context pointer** (wording not target decides reliability; the pointer-writing rules);
+    **the two loads** (context load vs cognitive load; disclosure trades one for the other);
+    **information hierarchy** (in-file step > in-file reference > disclosed reference; inline
+    what every branch needs, disclose what only some reach); **progressive disclosure** (the
+    move down the ladder; branch test); **co-location** (a concept's definition, rules,
+    caveats under one heading; distinct from duplication and scattering); **completion
+    criteria** (every step ends on one — checkable and exhaustive; a fuzzy bound invites
+    premature completion; sharpen the bound first, split the sequence only if the rush
+    persists and only across a real context boundary); **when to split** (by sequence — later
+    steps tempt a rush; by invocation — a distinct leading word triggers it, or another
+    skill must reach it); **leading words** (a compact pretrained concept repeated as a
+    token, never a sentence; prefer an existing word — coining costs definition tokens);
+    **steer positive** (state the target behaviour; a prohibition drags the banned behaviour
+    into context — reserve it for a hard guardrail paired with the positive); **pruning**
+    (one source of truth per meaning; the environment is a source of truth too — cache only
+    the lookup the agent cannot do by looking; check every line for relevance; hunt no-ops —
+    an instruction the model already obeys by default, tested by running the document).
+  - `## Model- vs user-invoked` — model-invoked keeps a `description` (agent and other skills
+    can fire it; permanent context load); user-invoked sets `disable-model-invocation: true`
+    (human-only, zero context load, spends cognitive load; `description` becomes a
+    human-facing one-liner with the trigger list stripped). A **router skill** is one
+    user-invoked skill that names the others and when to reach for each, when they multiply
+    past what the human can remember.
+  - `## When to add scripts` — kept.
+  - `## When to split files` — reconciled: past ~150 lines `SKILL.md` is a sprawl smell —
+    look for reference to disclose or a sequence to split; the branch test is the real
+    driver, not the line count.
+  - `## Common failure modes` — a named one-line-each list: **Sprawl** (too long even when
+    every line is live -> disclose reference, split by branch/sequence); **Negation
+    steering** (a "don't X" makes X more available -> prompt the positive); **Duplication**
+    (one meaning in two places -> single source of truth); **Scattering** (one meaning
+    fragmented across headings -> co-locate); **No-op** (a line the model already obeys ->
+    delete the sentence, or use a stronger leading word); **Premature completion** (a step
+    stops before it is done -> sharpen the criterion, then split the sequence).
+  - `## Review checklist` — revised, ~10 grouped pass/fail items:
+    - Pointer: description front-loads the trigger word; one trigger per branch; no identity
+      the body repeats; third person; <=1024 chars; second sentence is "Use when …".
+    - Hierarchy: branch-only sections are disclosed behind a pointer; every-branch material
+      is in-file; `SKILL.md` is not sprawling (~150); references are one level deep.
+    - Completion criteria: every step ends on a checkable and exhaustive criterion.
+    - Leading words / positivity: reaches for >=1 leading word where a triad or phrase
+      repeats; steers positive (a "don't …" appears only as a guardrail paired with the
+      positive target).
+    - General: `name:` matches the directory; no time-sensitive info; consistent
+      terminology; concrete examples included.
+- **`create-a-skill` passes its own revised checklist** — this is an explicit acceptance
+  criterion and a code-review Spec-axis check, not just an aspiration.
+
+## Testing Decisions
+
+- No executable code — skill prose only. No test files; no shell/prose test harness in this
+  repo. Consistent with the `uv-support`, `sync-hook-interpreter-selection`, and
+  `create-worktrees-dependency-bootstrap` slices this session.
+- Verification:
+  1. **Self-apply**: run the revised Review Checklist against `create-a-skill`'s own
+     `SKILL.md` and `REFERENCE.md`; every item passes.
+  2. **Read-through**: each lever line is imperative and ends on a check; checklist items are
+     pass/fail; each lever's rule is stated once (in `## Writing levers`) and referenced —
+     not restated — by `SKILL.md` and the checklist; repo-specific process is visually
+     separate from the universal levers.
+  3. **Line count**: `SKILL.md` <= ~150 (target ~90); `REFERENCE.md` legible, no sprawl.
+  4. `pre-commit run --all-files` passes (markdownlint, markdown-link-check, codespell).
+  5. `code-review` Standards + Spec axes.
+
+## Out of Scope
+
+- The other audit findings: `behaviour-driven-development`'s `name: bdd` vs its directory,
+  `pr-cleanup`'s missing "Use when" trigger, `address-copilot-comments`'s `SKILL.md` length,
+  and any other skill's compliance. Separate follow-ups; this branch is `create-a-skill/`
+  (plus the `context.md` glossary) only.
+- Reproducing `writing-for-agents` in full — the levers become terse rules, not paragraphs
+  of exposition.
+- A runtime dependency on `mattpocock-skills:writing-for-agents` being installed.
+- Changing `create-a-skill`'s own invocation model or `name` (stays model-invoked,
+  `name: create-a-skill`).
+- New executable scripts — `create-a-skill` stays instructions-only.
+- An ADR — improving a skill's guidance is reversible, unsurprising, and the one real
+  trade-off (self-contained vs point-at-plugin) is small and decided.
+
+## Further Notes
+
+- Reframing the split rule to "~150 = sprawl smell, branch test drives it" softens the
+  earlier compliance audit: `code-review/SKILL.md` at 106 lines is fine under the new rule;
+  `address-copilot-comments/SKILL.md` at 173 becomes "look for reference to disclose" rather
+  than a hard fail. Those remain separate follow-ups.
+- Source: `mattpocock-skills:writing-for-agents` v1.2.3 — `SKILL.md` and `SKILL-MECHANICS.md`
+  (read during the grill; copies stashed in the session scratchpad).

--- a/.agent-docs/specs/chore/improve-create-a-skill.md
+++ b/.agent-docs/specs/chore/improve-create-a-skill.md
@@ -96,9 +96,9 @@ branch test, not the line count, is the real driver.
     caveats under one heading; distinct from duplication and scattering); **completion
     criteria** (every step ends on one — checkable and exhaustive; a fuzzy bound invites
     premature completion; sharpen the bound first, split the sequence only if the rush
-    persists and only across a real context boundary); **when to split** (by sequence — later
-    steps tempt a rush; by invocation — a distinct leading word triggers it, or another
-    skill must reach it); **leading words** (a compact pretrained concept repeated as a
+    persists and only across a real context boundary); **when to split** (by sequence — the **sequence test**, coined
+    there as a token mirroring the branch test — when later steps tempt a rush; by
+    invocation — a distinct leading word triggers it, or another skill must reach it); **leading words** (a compact pretrained concept repeated as a
     token, never a sentence; prefer an existing word — coining costs definition tokens);
     **steer positive** (state the target behaviour; a prohibition drags the banned behaviour
     into context — reserve it for a hard guardrail paired with the positive); **pruning**

--- a/.agent-docs/specs/chore/improve-create-a-skill.md
+++ b/.agent-docs/specs/chore/improve-create-a-skill.md
@@ -151,7 +151,7 @@ branch test, not the line count, is the real driver.
      pass/fail; each lever's rule is stated once (in `## Writing levers`) and referenced —
      not restated — by `SKILL.md` and the checklist; repo-specific process is visually
      separate from the universal levers.
-  3. **Line count**: `SKILL.md` <= ~150 (target ~90); `REFERENCE.md` legible, no sprawl.
+  3. **Line count**: `SKILL.md` <= ~150 (target ~55); `REFERENCE.md` legible, no sprawl.
   4. `pre-commit run --all-files` passes (markdownlint, markdown-link-check, codespell).
   5. `code-review` Standards + Spec axes.
 

--- a/create-a-skill/REFERENCE.md
+++ b/create-a-skill/REFERENCE.md
@@ -74,7 +74,7 @@ Every item is pass/fail. A skill that fails one is not done.
 
 ### Hierarchy & disclosure
 
-- [ ] Material every run needs is in `SKILL.md`; branch-only sections are disclosed behind a pointer; references are one level deep.
+- [ ] Each step's actions are in `SKILL.md`; the rules and reference a step consults may sit behind a pointer the step names; branch-only material is disclosed, not inline. References are one level deep.
 - [ ] `SKILL.md` is not sprawling — see *When to split files*.
 
 ### Completion criteria

--- a/create-a-skill/REFERENCE.md
+++ b/create-a-skill/REFERENCE.md
@@ -1,16 +1,16 @@
 # create-a-skill — Reference
 
-The writing levers, the description rules, and the review checklist. The process and structure are in [SKILL.md](SKILL.md). The levers are adapted from Matt Pocock's `writing-for-agents` skill.
+The writing levers, the description rules, and the Review Checklist. The process and structure are in [SKILL.md](SKILL.md). The levers are adapted from Matt Pocock's `writing-for-agents` skill.
 
 ## Description requirements
 
-The `description` is the only thing the agent sees when choosing which skill to load — it is the skill's top-level **context pointer**. Give the agent enough to know *what capability this is* and *when to trigger it*.
+The `description` is the agent's main signal when choosing which skill to load — the skill's top-level **context pointer**. It must let the agent know *what capability this is* and *when to trigger it*.
 
 - Third person; max 1024 chars.
 - First sentence: what the skill does. Second sentence: "Use when [triggers]".
-- **Front-load the trigger word** — the pointer does its work at the start.
-- **One trigger per branch.** Synonyms that rename a single branch ("create, write, or build a skill") are one branch written three times — collapse them; keep only genuinely distinct cases.
-- **Cut identity the body already carries** — every word costs on every turn.
+- Front-load the trigger word — the pointer does its work at the start.
+- One trigger per branch. Synonyms that rename a single branch ("create, write, or build a skill") are one branch written three times; keep only genuinely distinct cases.
+- Cut identity the body already carries — every word costs on every turn.
 
 Good: `Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.`
 
@@ -18,29 +18,31 @@ Bad: `Helps with documents.` — nothing distinguishes it from other document sk
 
 ## Writing levers
 
-**Context pointer.** A reference plus the branches that should trigger reaching it. The wording, not the target, decides how reliably it fires — sharpen a weak pointer before you inline the material it guards.
+Each lever ends on a check the draft has to pass.
 
-**The two loads.** Every document or pointer spends one of two budgets: *context load* (always-loaded tokens on the agent's window) or *cognitive load* (the human having to remember the skill exists). Disclosure trades the first for the second.
+**Context pointer.** A reference that names out-of-context material plus the branches that trigger reaching it; its wording, not its target, sets how reliably it fires. *Check: from the pointer alone, can a reader name the exact cases that should load the material?*
 
-**Information hierarchy.** Rank material by how immediately the agent needs it: (1) in-file step, (2) in-file reference — a flat peer-set of rules is fine here, (3) disclosed reference behind a pointer. Push too little down and the top bloats; push too much and you hide what the agent needs.
+**The two loads.** A pointer or always-loaded line spends *context load* (tokens every turn); an unpointered doc spends *cognitive load* (the human remembering it exists). *Check: does each line earn the load it spends?*
 
-**Progressive disclosure.** The move down the ladder — out of `SKILL.md`, behind a pointer. Branch test: inline what every branch needs, disclose what only some reach.
+**Information hierarchy.** Rank material by how soon the agent needs it: in-file step, then in-file reference, then disclosed reference behind a pointer. *Check: is anything a run always needs behind a pointer it might skip, or any branch-only detail bloating the top?*
 
-**Co-location.** Keep a concept's definition, rules, and caveats under one heading, so reading one part brings its neighbours. Scattering fragments one meaning across headings; duplication repeats one meaning in two places — co-location is the fix for scattering.
+**Progressive disclosure.** Move branch-only material out of `SKILL.md` behind a pointer; keep what every branch needs inline. *Check: for each disclosed section, do only some branches reach it?*
 
-**Completion criteria.** Every step ends on one. Make it *checkable* (the agent can tell done from not-done) and *exhaustive* ("every model accounted for", not "produce a list"). A fuzzy bound invites premature completion — the step stops early because the visible later steps pull attention to *being done*. Sharpen the bound first; only if it stays fuzzy and you see the rush, hide the later steps by splitting the sequence across a real context boundary (a hand-off or subagent — an inline call clears nothing).
+**Co-location.** A concept's definition, rules, and caveats sit under one heading. *Check: does reading one part of a concept bring its caveats with it?*
 
-**When to split.** *By sequence* — when later steps tempt the agent to rush the one in front. *By invocation* — when a distinct leading word should trigger part of it on its own, or another skill must reach it. Each split spends a load, so it has to earn it.
+**Completion criteria.** Every step ends on a condition that is *checkable* (done vs not-done) and *exhaustive* ("every X accounted for", not "produce a list"). A fuzzy bound invites premature completion — the step stops early as attention slips to *being done*; sharpen the bound before hiding later steps, and hiding works only across a real context boundary (a hand-off or subagent, not an inline call). *Check: can the agent tell done from not-done, and does the bound force the whole job?*
 
-**Leading words.** A compact concept already in the model's pretraining (`tracer bullet`, `red`, `fog of war`), repeated as a token and never spelled out as a sentence, anchors a region of behaviour in the fewest tokens. Prefer an existing word — coining your own works only if you define it, and you pay in definition tokens what a pretrained word gives free. Hunt for triads and gesturing sentences that collapse into one: "fast, deterministic, low-overhead" → *tight*.
+**When to split.** Split by sequence when later steps tempt a rush of the current one; split by invocation when a distinct leading word should trigger a part on its own, or another skill must reach it. *Check: does the cut buy more legwork or independent reach than the load it spends?*
 
-**Steer positive.** State the target behaviour. A "don't X" drags X into context and makes it *more* available — reserve prohibition for a hard guardrail, and pair it with the positive target so attention lands on what to do.
+**Leading words.** A compact concept already in the model's pretraining (`tracer bullet`, `red`, `fog of war`), repeated as a token and never spelled out; prefer an existing word — a coined one costs the definition tokens a pretrained word gives free. *Check: is any triad or gesturing sentence begging to collapse into one word — "fast, deterministic, low-overhead" → *tight*?*
 
-**Pruning.** One source of truth per meaning — changing behaviour should be a one-place edit. The environment (`package.json` scripts, config, `--help`) is a source of truth too: restate it only when the lookup is expensive — cache the unwritten convention or the reason behind a choice, not the one-command lookup. Check every line for relevance. Hunt no-ops: a line the model already obeys by default; test it by running the document, and delete the whole sentence when it fails. A leading word too weak to beat the default is a no-op too — reach for a stronger word.
+**Steer positive.** State the target behaviour; a prohibition drags the banned thing into context and makes it *more* available. Reserve "don't" for a hard guardrail, paired with the positive target. *Check: does every instruction name what to do rather than what to avoid?*
+
+**Pruning.** One source of truth per meaning — changing behaviour is a one-place edit. The environment (`package.json` scripts, config, `--help`) is a source of truth too: restate it only when the lookup is expensive. *Check: run the document — did any line change behaviour versus the model's default? Would changing any rule take more than a one-place edit?*
 
 ## Model- vs user-invoked
 
-- **Model-invoked** — keeps a `description`, so the agent can fire it autonomously and other skills can reach it. Permanent context load in exchange for discoverability. Omit `disable-model-invocation`; write the description to the pointer rules above.
+- **Model-invoked** — keeps a `description`, so the agent can fire it autonomously and other skills can reach it. Permanent context load for discoverability. Omit `disable-model-invocation`; write the description to the rules above.
 - **User-invoked** — set `disable-model-invocation: true`. Only the human typing its name invokes it; no other skill can. Zero context load, but it spends cognitive load — the human is the index. The `description` becomes a human-facing one-liner with the trigger list stripped.
 
 Pick model-invocation only when the agent or another skill must reach the skill on its own. When user-invoked skills multiply past what the human can remember, add a **router skill** — one user-invoked skill that names the others and when to reach for each.
@@ -51,7 +53,7 @@ Add a utility script when the operation is deterministic (validation, formatting
 
 ## When to split files
 
-Split `SKILL.md` when a section is reached by only some branches (disclose it), or when a run of steps tempts a rush (split the sequence). Past ~150 lines is a **sprawl smell** — attention thins across the excess — so look for one of those cuts. The branch and sequence tests drive the split; the line count only tells you to look.
+Split `SKILL.md` when a section is branch-only (disclose it) or a run of steps tempts a rush (split the sequence). Past ~150 lines is a **sprawl smell** — attention thins across the excess — so look for one of those cuts. The branch and sequence tests drive the split; the line count only says to look.
 
 ## Common failure modes
 
@@ -62,21 +64,22 @@ Split `SKILL.md` when a section is reached by only some branches (disclose it), 
 - **No-op** — a line the model already obeys by default. → Delete the sentence, or use a stronger leading word.
 - **Premature completion** — a step stops before it is done. → Sharpen the criterion; then split the sequence if the rush persists.
 
-## Review checklist
+## Review Checklist
+
+Every item is pass/fail. A skill that fails one is not done.
 
 ### Pointer
 
-- [ ] Description is third person, ≤ 1024 chars; first sentence says what it does, second is "Use when …".
-- [ ] The trigger word is front-loaded; one trigger per branch (no synonym-branches); no identity the body already carries.
+- [ ] Description passes every rule in *Description requirements* (third person; ≤ 1024 chars; two sentences; front-loaded trigger word; one trigger per branch; no identity the body carries).
 
 ### Hierarchy & disclosure
 
-- [ ] Every-branch material is in `SKILL.md`; branch-only sections are disclosed behind a pointer.
-- [ ] `SKILL.md` is not sprawling (~150 lines); references are one level deep.
+- [ ] Material every run needs is in `SKILL.md`; branch-only sections are disclosed behind a pointer; references are one level deep.
+- [ ] `SKILL.md` is not sprawling — see *When to split files*.
 
 ### Completion criteria
 
-- [ ] Every step ends on a criterion that is both checkable and exhaustive.
+- [ ] Every step ends on a criterion that is checkable and exhaustive.
 
 ### Leading words & positivity
 

--- a/create-a-skill/REFERENCE.md
+++ b/create-a-skill/REFERENCE.md
@@ -26,7 +26,7 @@ Each lever ends on a check the draft has to pass.
 
 **Information hierarchy.** Rank material by how soon the agent needs it: in-file step, then in-file reference, then disclosed reference behind a pointer. *Check: is anything a run always needs behind a pointer it might skip, or any branch-only detail bloating the top?*
 
-**Progressive disclosure.** Move branch-only material out of `SKILL.md` behind a pointer; keep what every branch needs inline. *Check: for each disclosed section, do only some branches reach it?*
+**Progressive disclosure.** Move branch-only material out of `SKILL.md` behind a pointer; keep what every branch needs inline — the **branch test**. *Check: for each disclosed section, do only some branches reach it?*
 
 **Co-location.** A concept's definition, rules, and caveats sit under one heading. *Check: does reading one part of a concept bring its caveats with it?*
 

--- a/create-a-skill/REFERENCE.md
+++ b/create-a-skill/REFERENCE.md
@@ -7,7 +7,7 @@ The writing levers, the description rules, and the Review Checklist. The process
 The `description` is the agent's main signal when choosing which skill to load — the skill's top-level **context pointer**. It must let the agent know *what capability this is* and *when to trigger it*. These rules govern a **model-invoked** skill's description; a user-invoked skill drops the trigger list and keeps a human-facing one-liner (see *Model- vs user-invoked*).
 
 - Third person; max 1024 chars.
-- First sentence: what the skill does. Second sentence: "Use when [triggers]".
+- Exactly two sentences — first: what the skill does; second: "Use when [triggers]".
 - Front-load the trigger word — the pointer does its work at the start.
 - One trigger per branch. Synonyms that rename a single branch ("create, write, or build a skill") are one branch written three times; keep only genuinely distinct cases.
 - Cut identity the body already carries — every word costs on every turn.
@@ -24,7 +24,7 @@ Each lever ends on a check the draft has to pass.
 
 *Check: from the pointer alone, can a reader name the exact cases that should load the material?*
 
-**The two loads.** A pointer or always-loaded line spends *context load* (tokens every turn); an unpointered doc spends *cognitive load* (the human remembering it exists).
+**The two loads.** A pointer or always-loaded line spends *context load* (tokens every turn); a doc that no pointer names spends *cognitive load* (the human remembering it exists).
 
 *Check: does each line earn the load it spends?*
 

--- a/create-a-skill/REFERENCE.md
+++ b/create-a-skill/REFERENCE.md
@@ -4,7 +4,7 @@ The writing levers, the description rules, and the Review Checklist. The process
 
 ## Description requirements
 
-The `description` is the agent's main signal when choosing which skill to load — the skill's top-level **context pointer**. It must let the agent know *what capability this is* and *when to trigger it*.
+The `description` is the agent's main signal when choosing which skill to load — the skill's top-level **context pointer**. It must let the agent know *what capability this is* and *when to trigger it*. These rules govern a **model-invoked** skill's description; a user-invoked skill drops the trigger list and keeps a human-facing one-liner (see *Model- vs user-invoked*).
 
 - Third person; max 1024 chars.
 - First sentence: what the skill does. Second sentence: "Use when [triggers]".
@@ -12,7 +12,7 @@ The `description` is the agent's main signal when choosing which skill to load �
 - One trigger per branch. Synonyms that rename a single branch ("create, write, or build a skill") are one branch written three times; keep only genuinely distinct cases.
 - Cut identity the body already carries — every word costs on every turn.
 
-Good: `Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.`
+Good: `Extracts text and tables from PDF files, fills forms, merges documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.`
 
 Bad: `Helps with documents.` — nothing distinguishes it from other document skills.
 
@@ -20,25 +20,45 @@ Bad: `Helps with documents.` — nothing distinguishes it from other document sk
 
 Each lever ends on a check the draft has to pass.
 
-**Context pointer.** A reference that names out-of-context material plus the branches that trigger reaching it; its wording, not its target, sets how reliably it fires. *Check: from the pointer alone, can a reader name the exact cases that should load the material?*
+**Context pointer.** A reference that names out-of-context material plus the branches that trigger reaching it; its wording, not its target, sets how reliably it fires.
 
-**The two loads.** A pointer or always-loaded line spends *context load* (tokens every turn); an unpointered doc spends *cognitive load* (the human remembering it exists). *Check: does each line earn the load it spends?*
+*Check: from the pointer alone, can a reader name the exact cases that should load the material?*
 
-**Information hierarchy.** Rank material by how soon the agent needs it: in-file step, then in-file reference, then disclosed reference behind a pointer. *Check: is anything a run always needs behind a pointer it might skip, or any branch-only detail bloating the top?*
+**The two loads.** A pointer or always-loaded line spends *context load* (tokens every turn); an unpointered doc spends *cognitive load* (the human remembering it exists).
 
-**Progressive disclosure.** Move branch-only material out of `SKILL.md` behind a pointer; keep what every branch needs inline — the **branch test**. *Check: for each disclosed section, do only some branches reach it?*
+*Check: does each line earn the load it spends?*
 
-**Co-location.** A concept's definition, rules, and caveats sit under one heading. *Check: does reading one part of a concept bring its caveats with it?*
+**Information hierarchy.** Rank material by how soon the agent needs it: in-file step, then in-file reference, then disclosed reference behind a pointer.
 
-**Completion criteria.** Every step ends on a condition that is *checkable* (done vs not-done) and *exhaustive* ("every X accounted for", not "produce a list"). A fuzzy bound invites premature completion — the step stops early as attention slips to *being done*; sharpen the bound before hiding later steps, and hiding works only across a real context boundary (a hand-off or subagent, not an inline call). *Check: can the agent tell done from not-done, and does the bound force the whole job?*
+*Check: is anything a run always needs behind a pointer it might skip, or any branch-only detail bloating the top?*
 
-**When to split.** Split by sequence — the **sequence test** — when later steps tempt a rush of the current one; split by invocation when a distinct leading word should trigger a part on its own, or another skill must reach it. *Check: does the cut buy more legwork or independent reach than the load it spends?*
+**Progressive disclosure.** Move branch-only material out of `SKILL.md` behind a pointer; keep what every branch needs inline — the **branch test**.
 
-**Leading words.** A compact concept already in the model's pretraining (`tracer bullet`, `red`, `fog of war`), repeated as a token and never spelled out; prefer an existing word — a coined one costs the definition tokens a pretrained word gives free. *Check: is any triad or gesturing sentence begging to collapse into one word — "fast, deterministic, low-overhead" → *tight*?*
+*Check: for each disclosed section, do only some branches reach it?*
 
-**Steer positive.** State the target behaviour; a prohibition drags the banned thing into context and makes it *more* available. Reserve "don't" for a hard guardrail, paired with the positive target. *Check: does every instruction name what to do rather than what to avoid?*
+**Co-location.** A concept's definition, rules, and caveats sit under one heading.
 
-**Pruning.** One source of truth per meaning — changing behaviour is a one-place edit. The environment (`package.json` scripts, config, `--help`) is a source of truth too: restate it only when the lookup is expensive. *Check: run the document — did any line change behaviour versus the model's default? Would changing any rule take more than a one-place edit?*
+*Check: does reading one part of a concept bring its caveats with it?*
+
+**Completion criteria.** Every step ends on a condition that is *checkable* (done vs not-done) and *exhaustive* ("every X accounted for", not "produce a list"). A fuzzy bound invites premature completion — the step stops early as attention slips to *being done*; sharpen the bound before hiding later steps, and hiding works only across a real context boundary (a hand-off or subagent, not an inline call).
+
+*Check: can the agent tell done from not-done, and does the bound force the whole job?*
+
+**When to split.** Split by sequence — the **sequence test** — when later steps tempt a rush of the current one; split by invocation when a distinct leading word should trigger a part on its own, or another skill must reach it.
+
+*Check: does the cut buy more legwork or independent reach than the load it spends?*
+
+**Leading words.** A compact concept already in the model's pretraining (`tracer bullet`, `red`, `fog of war`), repeated as a token and never spelled out; prefer an existing word — a coined one costs the definition tokens a pretrained word gives free.
+
+*Check: is any triad or gesturing sentence begging to collapse into one word — "fast, deterministic, low-overhead" → *tight*?*
+
+**Steer positive.** State the target behaviour; a prohibition drags the banned thing into context and makes it *more* available. Reserve "don't" for a hard guardrail, paired with the positive target.
+
+*Check: does every instruction name what to do rather than what to avoid?*
+
+**Pruning.** One source of truth per meaning — changing behaviour is a one-place edit. The environment (`package.json` scripts, config, `--help`) is a source of truth too: restate it only when the lookup is expensive.
+
+*Check: run the document — did any line change behaviour versus the model's default? Would changing any rule take more than a one-place edit?*
 
 ## Model- vs user-invoked
 

--- a/create-a-skill/REFERENCE.md
+++ b/create-a-skill/REFERENCE.md
@@ -1,62 +1,90 @@
 # create-a-skill — Reference
 
-Description requirements and review checklist. The process and structure are in [SKILL.md](SKILL.md).
+The writing levers, the description rules, and the review checklist. The process and structure are in [SKILL.md](SKILL.md). The levers are adapted from Matt Pocock's `writing-for-agents` skill.
 
-## Description Requirements
+## Description requirements
 
-The description is **the only thing your agent sees** when deciding which skill to load. It's surfaced in the system prompt alongside all other installed skills. Your agent reads these descriptions and picks the relevant skill based on the user's request.
+The `description` is the only thing the agent sees when choosing which skill to load — it is the skill's top-level **context pointer**. Give the agent enough to know *what capability this is* and *when to trigger it*.
 
-**Goal**: Give your agent just enough info to know:
+- Third person; max 1024 chars.
+- First sentence: what the skill does. Second sentence: "Use when [triggers]".
+- **Front-load the trigger word** — the pointer does its work at the start.
+- **One trigger per branch.** Synonyms that rename a single branch ("create, write, or build a skill") are one branch written three times — collapse them; keep only genuinely distinct cases.
+- **Cut identity the body already carries** — every word costs on every turn.
 
-1. What capability this skill provides
-2. When/why to trigger it (specific keywords, contexts, file types)
+Good: `Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when the user mentions PDFs, forms, or document extraction.`
 
-**Format**:
+Bad: `Helps with documents.` — nothing distinguishes it from other document skills.
 
-- Max 1024 chars
-- Write in third person
-- First sentence: what it does
-- Second sentence: "Use when [specific triggers]"
+## Writing levers
 
-**Good example**:
+**Context pointer.** A reference plus the branches that should trigger reaching it. The wording, not the target, decides how reliably it fires — sharpen a weak pointer before you inline the material it guards.
 
-```text
-Extract text and tables from PDF files, fill forms, merge documents. Use when working with PDF files or when user mentions PDFs, forms, or document extraction.
-```
+**The two loads.** Every document or pointer spends one of two budgets: *context load* (always-loaded tokens on the agent's window) or *cognitive load* (the human having to remember the skill exists). Disclosure trades the first for the second.
 
-**Bad example**:
+**Information hierarchy.** Rank material by how immediately the agent needs it: (1) in-file step, (2) in-file reference — a flat peer-set of rules is fine here, (3) disclosed reference behind a pointer. Push too little down and the top bloats; push too much and you hide what the agent needs.
 
-```text
-Helps with documents.
-```
+**Progressive disclosure.** The move down the ladder — out of `SKILL.md`, behind a pointer. Branch test: inline what every branch needs, disclose what only some reach.
 
-The bad example gives your agent no way to distinguish this from other document skills.
+**Co-location.** Keep a concept's definition, rules, and caveats under one heading, so reading one part brings its neighbours. Scattering fragments one meaning across headings; duplication repeats one meaning in two places — co-location is the fix for scattering.
 
-## When to Add Scripts
+**Completion criteria.** Every step ends on one. Make it *checkable* (the agent can tell done from not-done) and *exhaustive* ("every model accounted for", not "produce a list"). A fuzzy bound invites premature completion — the step stops early because the visible later steps pull attention to *being done*. Sharpen the bound first; only if it stays fuzzy and you see the rush, hide the later steps by splitting the sequence across a real context boundary (a hand-off or subagent — an inline call clears nothing).
 
-Add utility scripts when:
+**When to split.** *By sequence* — when later steps tempt the agent to rush the one in front. *By invocation* — when a distinct leading word should trigger part of it on its own, or another skill must reach it. Each split spends a load, so it has to earn it.
 
-- Operation is deterministic (validation, formatting)
-- Same code would be generated repeatedly
-- Errors need explicit handling
+**Leading words.** A compact concept already in the model's pretraining (`tracer bullet`, `red`, `fog of war`), repeated as a token and never spelled out as a sentence, anchors a region of behaviour in the fewest tokens. Prefer an existing word — coining your own works only if you define it, and you pay in definition tokens what a pretrained word gives free. Hunt for triads and gesturing sentences that collapse into one: "fast, deterministic, low-overhead" → *tight*.
 
-Scripts save tokens and improve reliability vs generated code.
+**Steer positive.** State the target behaviour. A "don't X" drags X into context and makes it *more* available — reserve prohibition for a hard guardrail, and pair it with the positive target so attention lands on what to do.
 
-## When to Split Files
+**Pruning.** One source of truth per meaning — changing behaviour should be a one-place edit. The environment (`package.json` scripts, config, `--help`) is a source of truth too: restate it only when the lookup is expensive — cache the unwritten convention or the reason behind a choice, not the one-command lookup. Check every line for relevance. Hunt no-ops: a line the model already obeys by default; test it by running the document, and delete the whole sentence when it fails. A leading word too weak to beat the default is a no-op too — reach for a stronger word.
 
-Split into separate files when:
+## Model- vs user-invoked
 
-- SKILL.md exceeds 100 lines
-- Content has distinct domains (finance vs sales schemas)
-- Advanced features are rarely needed
+- **Model-invoked** — keeps a `description`, so the agent can fire it autonomously and other skills can reach it. Permanent context load in exchange for discoverability. Omit `disable-model-invocation`; write the description to the pointer rules above.
+- **User-invoked** — set `disable-model-invocation: true`. Only the human typing its name invokes it; no other skill can. Zero context load, but it spends cognitive load — the human is the index. The `description` becomes a human-facing one-liner with the trigger list stripped.
 
-## Review Checklist
+Pick model-invocation only when the agent or another skill must reach the skill on its own. When user-invoked skills multiply past what the human can remember, add a **router skill** — one user-invoked skill that names the others and when to reach for each.
 
-After drafting, verify:
+## When to add scripts
 
-- [ ] Description includes triggers ("Use when...")
-- [ ] SKILL.md under 100 lines
-- [ ] No time-sensitive info
-- [ ] Consistent terminology
-- [ ] Concrete examples included
-- [ ] References one level deep
+Add a utility script when the operation is deterministic (validation, formatting), the same code would be generated repeatedly, or errors need explicit handling. Scripts save tokens and improve reliability over generated code.
+
+## When to split files
+
+Split `SKILL.md` when a section is reached by only some branches (disclose it), or when a run of steps tempts a rush (split the sequence). Past ~150 lines is a **sprawl smell** — attention thins across the excess — so look for one of those cuts. The branch and sequence tests drive the split; the line count only tells you to look.
+
+## Common failure modes
+
+- **Sprawl** — too long even when every line is live. → Disclose reference behind pointers; split by branch or sequence.
+- **Negation steering** — a "don't X" makes X more available. → Prompt the positive target.
+- **Duplication** — one meaning in two places; a two-place edit to change behaviour. → Single source of truth.
+- **Scattering** — one meaning fragmented across headings. → Co-locate under one heading.
+- **No-op** — a line the model already obeys by default. → Delete the sentence, or use a stronger leading word.
+- **Premature completion** — a step stops before it is done. → Sharpen the criterion; then split the sequence if the rush persists.
+
+## Review checklist
+
+### Pointer
+
+- [ ] Description is third person, ≤ 1024 chars; first sentence says what it does, second is "Use when …".
+- [ ] The trigger word is front-loaded; one trigger per branch (no synonym-branches); no identity the body already carries.
+
+### Hierarchy & disclosure
+
+- [ ] Every-branch material is in `SKILL.md`; branch-only sections are disclosed behind a pointer.
+- [ ] `SKILL.md` is not sprawling (~150 lines); references are one level deep.
+
+### Completion criteria
+
+- [ ] Every step ends on a criterion that is both checkable and exhaustive.
+
+### Leading words & positivity
+
+- [ ] Reaches for a leading word where a triad or phrase repeats.
+- [ ] Steers positive — a "don't …" appears only as a guardrail paired with the positive target.
+
+### General
+
+- [ ] `name:` matches the directory name.
+- [ ] No time-sensitive info; consistent terminology throughout.
+- [ ] Concrete examples included.

--- a/create-a-skill/REFERENCE.md
+++ b/create-a-skill/REFERENCE.md
@@ -32,7 +32,7 @@ Each lever ends on a check the draft has to pass.
 
 **Completion criteria.** Every step ends on a condition that is *checkable* (done vs not-done) and *exhaustive* ("every X accounted for", not "produce a list"). A fuzzy bound invites premature completion — the step stops early as attention slips to *being done*; sharpen the bound before hiding later steps, and hiding works only across a real context boundary (a hand-off or subagent, not an inline call). *Check: can the agent tell done from not-done, and does the bound force the whole job?*
 
-**When to split.** Split by sequence when later steps tempt a rush of the current one; split by invocation when a distinct leading word should trigger a part on its own, or another skill must reach it. *Check: does the cut buy more legwork or independent reach than the load it spends?*
+**When to split.** Split by sequence — the **sequence test** — when later steps tempt a rush of the current one; split by invocation when a distinct leading word should trigger a part on its own, or another skill must reach it. *Check: does the cut buy more legwork or independent reach than the load it spends?*
 
 **Leading words.** A compact concept already in the model's pretraining (`tracer bullet`, `red`, `fog of war`), repeated as a token and never spelled out; prefer an existing word — a coined one costs the definition tokens a pretrained word gives free. *Check: is any triad or gesturing sentence begging to collapse into one word — "fast, deterministic, low-overhead" → *tight*?*
 

--- a/create-a-skill/SKILL.md
+++ b/create-a-skill/SKILL.md
@@ -11,7 +11,7 @@ A skill is predictable when the agent takes the same *process* every run — not
 
 1. **Gather requirements** — get an answer to each of: the task or domain and its concrete use cases; a utility script or instructions only; reference material to bundle or point at; model-invoked or user-invoked (REFERENCE.md). Drafting starts once every one is answered.
 
-2. **Place each piece of content on the information hierarchy** (REFERENCE.md), by the branch test. Done when every piece has a place.
+2. **Place each piece of content on the information hierarchy** (REFERENCE.md); the branch test (see *Progressive disclosure*) decides what to disclose. Done when every piece has a place.
 
 3. **Draft** `SKILL.md`, plus `REFERENCE.md` / `EXAMPLES.md` / `scripts/` for whatever step 2 put there, applying every writing lever from REFERENCE.md as you write. Done when every lever holds.
 

--- a/create-a-skill/SKILL.md
+++ b/create-a-skill/SKILL.md
@@ -1,46 +1,36 @@
 ---
 name: create-a-skill
-description: Create, revise, or review a Claude Code agent skill — structured on the information hierarchy, with a description that triggers reliably and steps that stop on a real criterion. Use when the user wants to write a new skill, rework an existing one, or check a skill against the writing levers.
+description: Create, revise, or review a Claude Code agent skill. Use when the user wants to write a new skill, rework an existing one, or review a skill against the writing levers.
 ---
 
 # Writing Skills
 
-A skill is predictable when the agent takes the same *process* every run — not when it produces the same output. The levers that buy that, the description rules, and the review checklist are in [REFERENCE.md](REFERENCE.md).
+A skill is predictable when the agent takes the same *process* every run — not when it produces the same output. The **writing levers** that buy that, the description rules, the model/user-invocation choice, and the Review Checklist are all in [REFERENCE.md](REFERENCE.md).
 
 ## Process
 
-1. **Gather requirements** — get an answer to each before drafting:
-   - What task or domain does the skill cover? Which use cases, concretely?
-   - A utility script (a deterministic operation), or instructions only?
-   - Reference material to bundle or point at?
-   - **Model-invoked or user-invoked?** The agent (or another skill) must reach it on its own → model-invoked. It only ever fires by hand → user-invoked. See the Model- vs user-invoked section in REFERENCE.md.
-   Continue once every question has an answer.
+1. **Gather requirements** — get an answer to each of: the task or domain and its concrete use cases; a utility script or instructions only; reference material to bundle or point at; model-invoked or user-invoked (REFERENCE.md). Drafting starts once every one is answered.
 
-2. **Place each piece of content on the information hierarchy** — an in-file step (an ordered action), in-file reference (consulted on demand), or disclosed reference (pushed into a pointer-reached file). Branch test: inline what every run needs, disclose what only some branches reach. Stop when every piece has a place.
+2. **Place each piece of content on the information hierarchy** (REFERENCE.md) — in-file step, in-file reference, or disclosed reference — by the branch test. Done when every piece has a place.
 
-3. **Draft** — `SKILL.md`, plus `REFERENCE.md` / `EXAMPLES.md` / `scripts/` when step 2 or sprawl calls for them:
-   - Write the `description` as a **context pointer** — front-load the trigger word, one trigger per branch, cut identity the body already carries.
-   - End every step on a **completion criterion** that is checkable (done vs not-done) *and* exhaustive ("every X accounted for", not "produce a list").
-   - Reach for a **leading word** where a triad or phrase repeats. State behaviour **positively** — a "don't …" only as a hard guardrail paired with the positive target.
-   - Keep each meaning in one place; leave one-file, one-command lookups to the environment.
-   The draft is done when all four rules hold for every step and pointer.
+3. **Draft** `SKILL.md`, plus `REFERENCE.md` / `EXAMPLES.md` / `scripts/` for whatever step 2 put there, applying every writing lever from REFERENCE.md as you write. Done when every lever holds.
 
-4. **Review with the user** — does it cover the use cases? Anything missing, or over-detailed? Continue once the user confirms coverage.
+4. **Review with the user** — walk the use cases from step 1; done when each is covered and the user has nothing to add.
 
-5. **Verify against the Review Checklist in REFERENCE.md** — every item is pass/fail. A skill that fails one is not done.
+5. **Verify against the Review Checklist** (REFERENCE.md) — every item is pass/fail; a skill that fails one is not done.
 
 ## Skill structure
 
 ```text
 skill-name/
 ├── SKILL.md           # required — the process, placed on the information hierarchy
-├── REFERENCE.md       # disclosed reference (when branch-only content or sprawl warrants)
+├── REFERENCE.md       # disclosed reference (branch-only content, or sprawl)
 ├── EXAMPLES.md        # worked examples (same test)
 └── scripts/           # utility scripts (deterministic operations)
     └── helper.py
 ```
 
-`name:` matches the directory. `SKILL.md` past ~150 lines is a sprawl smell — look for reference to disclose or a sequence to split.
+`name:` matches the directory.
 
 ## SKILL.md template
 

--- a/create-a-skill/SKILL.md
+++ b/create-a-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-a-skill
-description: Create, rework, or review a Claude Code agent skill. Use when the user asks to build a skill, when an existing skill needs changing, or when checking a skill against the writing levers.
+description: Creates, reworks, or reviews a Claude Code agent skill. Use when the user asks to build a skill, when an existing skill needs changing, or when checking a skill against the writing levers.
 ---
 
 # Writing Skills
@@ -9,9 +9,9 @@ A skill is predictable when the agent takes the same *process* every run — not
 
 ## Process
 
-1. **Gather requirements** — get an answer to each of: the task or domain and its concrete use cases; a utility script or instructions only; reference material to bundle or point at; model-invoked or user-invoked (REFERENCE.md). Drafting starts once every one is answered.
+1. **Gather requirements** — get an answer to each of: the task or domain and its concrete use cases; a utility script or instructions only; reference material to bundle or point at; model-invoked or user-invoked (see *Model- vs user-invoked* in REFERENCE.md). Drafting starts once every one is answered.
 
-2. **Place each piece of content on the information hierarchy** (REFERENCE.md); the branch test (see *Progressive disclosure*) decides what to disclose. Done when every piece has a place.
+2. **Place each piece of content on the information hierarchy** (see *Information hierarchy* in REFERENCE.md); the branch test (see *Progressive disclosure*) decides what to disclose. Done when every piece has a place.
 
 3. **Draft** `SKILL.md`, plus `REFERENCE.md` / `EXAMPLES.md` / `scripts/` for whatever step 2 put there, applying every writing lever from REFERENCE.md as you write. Done when every lever holds.
 

--- a/create-a-skill/SKILL.md
+++ b/create-a-skill/SKILL.md
@@ -17,7 +17,7 @@ A skill is predictable when the agent takes the same *process* every run — not
 
 4. **Review with the user** — walk the use cases from step 1; done when each is covered and the user has nothing to add.
 
-5. **Verify against the Review Checklist** (REFERENCE.md) — every item is pass/fail; a skill that fails one is not done.
+5. **Verify against the Review Checklist** (REFERENCE.md) — every item is pass/fail. Done when every item passes; a skill that fails one is not done.
 
 ## Skill structure
 

--- a/create-a-skill/SKILL.md
+++ b/create-a-skill/SKILL.md
@@ -1,62 +1,67 @@
 ---
 name: create-a-skill
-description: Create new Claude Code agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.
+description: Create, revise, or review a Claude Code agent skill — structured on the information hierarchy, with a description that triggers reliably and steps that stop on a real criterion. Use when the user wants to write a new skill, rework an existing one, or check a skill against the writing levers.
 ---
 
 # Writing Skills
 
-See [REFERENCE.md](REFERENCE.md) for description requirements and the review checklist.
+A skill is predictable when the agent takes the same *process* every run — not when it produces the same output. The levers that buy that, the description rules, and the review checklist are in [REFERENCE.md](REFERENCE.md).
 
 ## Process
 
-1. **Gather requirements** - ask user about:
-   - What task/domain does the skill cover?
-   - What specific use cases should it handle?
-   - Does it need executable scripts or just instructions?
-   - Any reference materials to include?
+1. **Gather requirements** — get an answer to each before drafting:
+   - What task or domain does the skill cover? Which use cases, concretely?
+   - A utility script (a deterministic operation), or instructions only?
+   - Reference material to bundle or point at?
+   - **Model-invoked or user-invoked?** The agent (or another skill) must reach it on its own → model-invoked. It only ever fires by hand → user-invoked. See the Model- vs user-invoked section in REFERENCE.md.
+   Continue once every question has an answer.
 
-2. **Draft the skill** - create:
-   - SKILL.md with concise instructions
-   - Additional reference files if content exceeds 500 lines
-   - Utility scripts if deterministic operations needed
+2. **Place each piece of content on the information hierarchy** — an in-file step (an ordered action), in-file reference (consulted on demand), or disclosed reference (pushed into a pointer-reached file). Branch test: inline what every run needs, disclose what only some branches reach. Stop when every piece has a place.
 
-3. **Review with user** - present draft and ask:
-   - Does this cover your use cases?
-   - Anything missing or unclear?
-   - Should any section be more/less detailed?
+3. **Draft** — `SKILL.md`, plus `REFERENCE.md` / `EXAMPLES.md` / `scripts/` when step 2 or sprawl calls for them:
+   - Write the `description` as a **context pointer** — front-load the trigger word, one trigger per branch, cut identity the body already carries.
+   - End every step on a **completion criterion** that is checkable (done vs not-done) *and* exhaustive ("every X accounted for", not "produce a list").
+   - Reach for a **leading word** where a triad or phrase repeats. State behaviour **positively** — a "don't …" only as a hard guardrail paired with the positive target.
+   - Keep each meaning in one place; leave one-file, one-command lookups to the environment.
+   The draft is done when all four rules hold for every step and pointer.
 
-4. **Verify against checklist** — see the Review Checklist section in [REFERENCE.md](REFERENCE.md).
+4. **Review with the user** — does it cover the use cases? Anything missing, or over-detailed? Continue once the user confirms coverage.
 
-## Skill Structure
+5. **Verify against the Review Checklist in REFERENCE.md** — every item is pass/fail. A skill that fails one is not done.
+
+## Skill structure
 
 ```text
 skill-name/
-├── SKILL.md           # Main instructions (required)
-├── REFERENCE.md       # Detailed docs (if needed)
-├── EXAMPLES.md        # Usage examples (if needed)
-└── scripts/           # Utility scripts (if needed)
+├── SKILL.md           # required — the process, placed on the information hierarchy
+├── REFERENCE.md       # disclosed reference (when branch-only content or sprawl warrants)
+├── EXAMPLES.md        # worked examples (same test)
+└── scripts/           # utility scripts (deterministic operations)
     └── helper.py
 ```
 
-## SKILL.md Template
+`name:` matches the directory. `SKILL.md` past ~150 lines is a sprawl smell — look for reference to disclose or a sequence to split.
+
+## SKILL.md template
 
 ```md
 ---
 name: skill-name
-description: Brief description of capability. Use when [specific triggers].
+description: <what it does>. Use when <one trigger per branch>.
 ---
 
 # Skill Name
 
 ## Quick start
 
-[Minimal working example]
+<minimal working example>
 
 ## Workflows
 
-[Step-by-step processes with checklists for complex tasks]
+<steps, each ending on a completion criterion — e.g. "every changed file has a
+test and the full suite is green">
 
-## Advanced features
+## Advanced
 
-[Link to separate files: See [REFERENCE.md](REFERENCE.md)]
+See [REFERENCE.md](REFERENCE.md).
 ```

--- a/create-a-skill/SKILL.md
+++ b/create-a-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-a-skill
-description: Create, revise, or review a Claude Code agent skill. Use when the user wants to write a new skill, rework an existing one, or review a skill against the writing levers.
+description: Create, rework, or review a Claude Code agent skill. Use when the user asks to build a skill, when an existing skill needs changing, or when checking a skill against the writing levers.
 ---
 
 # Writing Skills
@@ -11,7 +11,7 @@ A skill is predictable when the agent takes the same *process* every run — not
 
 1. **Gather requirements** — get an answer to each of: the task or domain and its concrete use cases; a utility script or instructions only; reference material to bundle or point at; model-invoked or user-invoked (REFERENCE.md). Drafting starts once every one is answered.
 
-2. **Place each piece of content on the information hierarchy** (REFERENCE.md) — in-file step, in-file reference, or disclosed reference — by the branch test. Done when every piece has a place.
+2. **Place each piece of content on the information hierarchy** (REFERENCE.md), by the branch test. Done when every piece has a place.
 
 3. **Draft** `SKILL.md`, plus `REFERENCE.md` / `EXAMPLES.md` / `scripts/` for whatever step 2 put there, applying every writing lever from REFERENCE.md as you write. Done when every lever holds.
 
@@ -23,10 +23,10 @@ A skill is predictable when the agent takes the same *process* every run — not
 
 ```text
 skill-name/
-├── SKILL.md           # required — the process, placed on the information hierarchy
-├── REFERENCE.md       # disclosed reference (branch-only content, or sprawl)
-├── EXAMPLES.md        # worked examples (same test)
-└── scripts/           # utility scripts (deterministic operations)
+├── SKILL.md           # required — the process
+├── REFERENCE.md       # disclosed reference
+├── EXAMPLES.md        # worked examples
+└── scripts/           # utility scripts — see "When to add scripts"
     └── helper.py
 ```
 


### PR DESCRIPTION
## Problem

`create-a-skill` contradicted itself on when to split `SKILL.md` (step 2 said 500 lines; `REFERENCE.md` and the checklist said 100), and it taught structure without the levers that make a skill reliable — how a `description` triggers, where content sits relative to how urgently the agent needs it, what makes a stopping condition sound, how word choice steers behaviour. The concepts that fix this exist in Matt Pocock's `writing-for-agents` plugin but nothing in the repo pointed at them.

## Change

Rewrite `create-a-skill/SKILL.md` and `create-a-skill/REFERENCE.md` around a named set of **writing levers**, adapted from `writing-for-agents` into this repo's voice as terse, testable rules. `create-a-skill` is now self-contained (no runtime dependency on the plugin) and passes its own revised checklist.

- **`SKILL.md`** (~55 lines): 5-step process, each step ending on a completion criterion and naming the `REFERENCE.md` section for the rules rather than restating them. Keeps the structure diagram and template.
- **`REFERENCE.md`**: `Description requirements` folded with the pointer rules; `Writing levers` (10, each ending on a `*Check:*`); `Model- vs user-invoked` + router skills; `When to add scripts`; `When to split files` (owns the ~150 sprawl-smell rule, stated once); `Common failure modes` (named list); grouped `Review Checklist` that references the rules rather than re-spelling enumerations.
- **100-vs-500 contradiction** replaced by one rule: past ~150 lines `SKILL.md` is a sprawl smell prompting a look for reference to disclose or a sequence to split — the branch/sequence tests are the real driver, the line count only says to look.
- **`.agent-docs/context.md`**: 4 glossary terms (context pointer, information hierarchy, progressive disclosure, leading word).

Closes #79.

## Test plan

- No executable code — skill prose only.
- `create-a-skill` self-applies its revised Review Checklist — every item passes.
- `pre-commit run --all-files` clean (markdownlint, markdown-link-check, codespell).
- `code-review` Standards + Spec axes: two consecutive fully-clean passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)